### PR TITLE
feat: add NgRx state management foundation

### DIFF
--- a/boersencockpit/angular.json
+++ b/boersencockpit/angular.json
@@ -32,11 +32,17 @@
             ],
             "scripts": []
           },
-          "configurations": {
-            "production": {
-              "budgets": [
-                {
-                  "type": "initial",
+        "configurations": {
+          "production": {
+            "fileReplacements": [
+              {
+                "replace": "src/environments/environment.ts",
+                "with": "src/environments/environment.production.ts"
+              }
+            ],
+            "budgets": [
+              {
+                "type": "initial",
                   "maximumWarning": "500kb",
                   "maximumError": "1mb"
                 },

--- a/boersencockpit/package-lock.json
+++ b/boersencockpit/package-lock.json
@@ -16,6 +16,11 @@
         "@angular/platform-browser": "^17.3.0",
         "@angular/platform-browser-dynamic": "^17.3.0",
         "@angular/router": "^17.3.0",
+        "@ngrx/effects": "^17.2.0",
+        "@ngrx/entity": "^17.2.0",
+        "@ngrx/router-store": "^17.2.0",
+        "@ngrx/store": "^17.2.0",
+        "@ngrx/store-devtools": "^17.2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zod": "^3.23.8",
@@ -28,6 +33,7 @@
         "@angular-eslint/template-parser": "^17.4.1",
         "@angular/cli": "^17.3.17",
         "@angular/compiler-cli": "^17.3.0",
+        "@ngrx/schematics": "^17.2.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.11",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
@@ -38,6 +44,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "jest": "^29.7.0",
+        "jest-marbles": "^3.1.1",
         "jest-preset-angular": "^14.4.2",
         "postcss": "^8.4.41",
         "prettier": "^3.3.3",
@@ -3946,6 +3953,96 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/@ngrx/effects": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-17.2.0.tgz",
+      "integrity": "sha512-tXDJNsuBtbvI/7+vYnkDKKpUvLbopw1U5G6LoPnKNrbTPsPcUGmCqF5Su/ZoRN3BhXjt2j+eoeVdpBkxdxMRgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ngrx/operators": "17.0.0-beta.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^17.0.0",
+        "@ngrx/store": "17.2.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
+    "node_modules/@ngrx/entity": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/entity/-/entity-17.2.0.tgz",
+      "integrity": "sha512-epXgojGXCrVMNrFdv60704iRUU+pYkE1qHBppP/wqKbZZIZHaagsg2jy8/ptDP7U3udvVq0z9suc1s+zpmL2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^17.0.0",
+        "@ngrx/store": "17.2.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
+    "node_modules/@ngrx/operators": {
+      "version": "17.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/operators/-/operators-17.0.0-beta.0.tgz",
+      "integrity": "sha512-EbO8AONuQ6zo2v/mPyBOi4y0CTAp1x4Z+bx7ZF+Pd8BL5ma53BTCL1TmzaeK5zPUe0yApudLk9/ZbHXPnVox5A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@ngrx/router-store": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/router-store/-/router-store-17.2.0.tgz",
+      "integrity": "sha512-Vynfg2xsB57Oedf0Bb6mjC4MIeaF2OtAewsSnppGIM2b8pwL5W89r2+q2SGc2D6Mp3/pZF3HRI6NxhnHWJdYmg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^17.0.0",
+        "@angular/core": "^17.0.0",
+        "@angular/router": "^17.0.0",
+        "@ngrx/store": "17.2.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
+    "node_modules/@ngrx/schematics": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/schematics/-/schematics-17.2.0.tgz",
+      "integrity": "sha512-7YQyPWaadxY2+Fe0oFIkClMpEKsC2HaxdjJY8SRTLnFOHj070r3Kp6mxGee46MVdfDNK47bUYnMPQi9A25EcVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ngrx/store": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-17.2.0.tgz",
+      "integrity": "sha512-7wKgZ59B/6yQSvvsU0DQXipDqpkAXv7LwcXLD5Ww7nvqN0fQoRPThMh4+Wv55DCJhE0bQc1NEMciLA47uRt7Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^17.0.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
+    "node_modules/@ngrx/store-devtools": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/store-devtools/-/store-devtools-17.2.0.tgz",
+      "integrity": "sha512-ig0qr6hMexZGnrlxfHvZmu5CanRjH7hhx60XUbB5BdBvWJIIRaWKPLcsniiDUhljAD87gvzrrilbCTiML38+CA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@ngrx/store": "17.2.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
       }
     },
     "node_modules/@ngtools/webpack": {
@@ -11831,6 +11928,19 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-marbles": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jest-marbles/-/jest-marbles-3.1.1.tgz",
+      "integrity": "sha512-vl7aktKOl+yqZHCS3OTdjjZtbhS9ATG29gBzcFjlLZN54ZOaSPd3fXYULj9bN86r7eJttOSWUeeipXVXcAnltg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {

--- a/boersencockpit/package.json
+++ b/boersencockpit/package.json
@@ -27,10 +27,15 @@
     "@angular/platform-browser": "^17.3.0",
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
+    "@ngrx/effects": "^17.2.0",
+    "@ngrx/entity": "^17.2.0",
+    "@ngrx/router-store": "^17.2.0",
+    "@ngrx/store": "^17.2.0",
+    "@ngrx/store-devtools": "^17.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.14.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zone.js": "~0.14.3"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.3.17",
@@ -39,6 +44,7 @@
     "@angular-eslint/template-parser": "^17.4.1",
     "@angular/cli": "^17.3.17",
     "@angular/compiler-cli": "^17.3.0",
+    "@ngrx/schematics": "^17.2.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.11",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
@@ -49,6 +55,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
+    "jest-marbles": "^3.1.1",
     "jest-preset-angular": "^14.4.2",
     "postcss": "^8.4.41",
     "prettier": "^3.3.3",

--- a/boersencockpit/src/app/app.config.ts
+++ b/boersencockpit/src/app/app.config.ts
@@ -3,12 +3,17 @@ import { provideRouter, withInMemoryScrolling } from '@angular/router';
 
 import { APP_TIMEZONE } from './core/tokens/timezone.token';
 import { routes } from './app.routes';
+import { provideAppStore } from './store/app.store.module';
+import { PRICE_API } from './core/api/price-api.token';
+import { MockPriceApiService } from './core/api/mock-price-api.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes, withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })),
+    provideAppStore(),
     { provide: LOCALE_ID, useValue: 'de-DE' },
     { provide: DEFAULT_CURRENCY_CODE, useValue: 'EUR' },
     { provide: APP_TIMEZONE, useValue: 'Europe/Berlin' },
+    { provide: PRICE_API, useExisting: MockPriceApiService },
   ],
 };

--- a/boersencockpit/src/app/core/api/price-api.token.ts
+++ b/boersencockpit/src/app/core/api/price-api.token.ts
@@ -1,0 +1,5 @@
+import { InjectionToken } from '@angular/core';
+
+import { PriceApiPort } from './price-api.port';
+
+export const PRICE_API = new InjectionToken<PriceApiPort>('PRICE_API');

--- a/boersencockpit/src/app/core/errors/serializable-error.ts
+++ b/boersencockpit/src/app/core/errors/serializable-error.ts
@@ -1,0 +1,42 @@
+import { AppError } from './app-error';
+
+export interface SerializableError {
+  readonly message: string;
+  readonly code: string;
+  readonly cause?: string | null;
+}
+
+export const serializeError = (error: unknown, defaultCode = 'APP/UNKNOWN'): SerializableError => {
+  if (error instanceof AppError) {
+    return {
+      message: error.message,
+      code: error.code,
+      cause: serializeCause(error.cause),
+    };
+  }
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      code: defaultCode,
+      cause: error.name,
+    };
+  }
+  return {
+    message: typeof error === 'string' ? error : 'Unknown error',
+    code: defaultCode,
+    cause: null,
+  };
+};
+
+const serializeCause = (cause: unknown): string | null => {
+  if (cause instanceof AppError) {
+    return `${cause.code}: ${cause.message}`;
+  }
+  if (cause instanceof Error) {
+    return `${cause.name}: ${cause.message}`;
+  }
+  if (typeof cause === 'string') {
+    return cause;
+  }
+  return null;
+};

--- a/boersencockpit/src/app/features/portfolio/state/portfolio.actions.ts
+++ b/boersencockpit/src/app/features/portfolio/state/portfolio.actions.ts
@@ -1,0 +1,10 @@
+import { createAction, props } from '@ngrx/store';
+
+import { RangeKey } from '../../../core/api/price-api.port';
+
+export const portfolioRangeChanged = createAction(
+  '[Portfolio] Range Changed',
+  props<{ readonly range: RangeKey }>()
+);
+
+export const portfolioRecomputeRequested = createAction('[Portfolio] Recompute Requested');

--- a/boersencockpit/src/app/features/portfolio/state/portfolio.effects.spec.ts
+++ b/boersencockpit/src/app/features/portfolio/state/portfolio.effects.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Observable } from 'rxjs';
+
+import * as PortfolioActions from './portfolio.actions';
+import * as TradesActions from '../../trades/state/trades.actions';
+import * as QuotesActions from '../../quotes/state/quotes.actions';
+import * as TimeSeriesActions from '../../timeseries/state/timeseries.actions';
+import { PortfolioEffects } from './portfolio.effects';
+import { runMarbles } from '../../../testing/marble-helpers';
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { PriceQuote } from '../../../domain/models/quote';
+import { TimeSeries } from '../../../domain/models/candle';
+
+const symbol = asSymbol('AAPL');
+const quote: PriceQuote = { symbol, price: 100, changeAbs: 1, changePct: 1, asOf: '2024-01-01T00:00:00.000Z' };
+const series: TimeSeries = { symbol, candles: [{ t: '2024-01-01T00:00:00.000Z', o: 1, h: 1, l: 1, c: 1 }] };
+
+describe('PortfolioEffects', () => {
+  let actions$: Observable<unknown>;
+  let effects: PortfolioEffects;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PortfolioEffects, provideMockActions(() => actions$)],
+    });
+    effects = TestBed.inject(PortfolioEffects);
+  });
+
+  const expectRecompute = (action: unknown) => {
+    runMarbles(({ hot, expectObservable }) => {
+      actions$ = hot('-a', { a: action });
+      const expected = '-b';
+      const expectedValues = {
+        b: PortfolioActions.portfolioRecomputeRequested(),
+      };
+      expectObservable(effects.recomputeRequested$).toBe(expected, expectedValues);
+    });
+  };
+
+  it('triggers recompute on trade success', () => {
+    expectRecompute(TradesActions.addTradeSucceeded({
+      trade: {
+        id: '1',
+        symbol,
+        side: 'BUY',
+        quantity: 1,
+        price: 100,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      },
+    }));
+  });
+
+  it('triggers recompute on quote tick', () => {
+    expectRecompute(QuotesActions.quotesTickArrived({ quotes: [quote] }));
+  });
+
+  it('triggers recompute on time series success', () => {
+    expectRecompute(TimeSeriesActions.timeSeriesSucceeded({ symbol, range: '1M', series }));
+  });
+
+  it('triggers recompute on range change', () => {
+    expectRecompute(PortfolioActions.portfolioRangeChanged({ range: '3M' }));
+  });
+});

--- a/boersencockpit/src/app/features/portfolio/state/portfolio.effects.ts
+++ b/boersencockpit/src/app/features/portfolio/state/portfolio.effects.ts
@@ -1,0 +1,26 @@
+import { inject, Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { map } from 'rxjs/operators';
+
+import * as PortfolioActions from './portfolio.actions';
+import * as TradesActions from '../../trades/state/trades.actions';
+import * as QuotesActions from '../../quotes/state/quotes.actions';
+import * as TimeSeriesActions from '../../timeseries/state/timeseries.actions';
+
+@Injectable()
+export class PortfolioEffects {
+  private readonly actions$ = inject(Actions);
+
+  readonly recomputeRequested$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(
+        TradesActions.addTradeSucceeded,
+        TradesActions.removeTradeSucceeded,
+        QuotesActions.quotesTickArrived,
+        TimeSeriesActions.timeSeriesSucceeded,
+        PortfolioActions.portfolioRangeChanged
+      ),
+      map(() => PortfolioActions.portfolioRecomputeRequested())
+    )
+  );
+}

--- a/boersencockpit/src/app/features/portfolio/state/portfolio.models.ts
+++ b/boersencockpit/src/app/features/portfolio/state/portfolio.models.ts
@@ -1,0 +1,8 @@
+import { RangeKey } from '../../../core/api/price-api.port';
+
+export interface PortfolioState {
+  readonly selectedRange: RangeKey;
+  readonly revision: number;
+}
+
+export const PORTFOLIO_FEATURE_KEY = 'portfolio';

--- a/boersencockpit/src/app/features/portfolio/state/portfolio.reducer.spec.ts
+++ b/boersencockpit/src/app/features/portfolio/state/portfolio.reducer.spec.ts
@@ -1,0 +1,26 @@
+import * as PortfolioActions from './portfolio.actions';
+import { initialPortfolioState, portfolioReducer } from './portfolio.reducer';
+
+describe('portfolioReducer', () => {
+  it('returns initial state for unknown action', () => {
+    const state = portfolioReducer(undefined, { type: 'Unknown' });
+    expect(state).toEqual(initialPortfolioState);
+  });
+
+  it('updates range and revision on range change', () => {
+    const state = portfolioReducer(
+      initialPortfolioState,
+      PortfolioActions.portfolioRangeChanged({ range: '3M' })
+    );
+    expect(state.selectedRange).toBe('3M');
+    expect(state.revision).toBe(initialPortfolioState.revision + 1);
+  });
+
+  it('increments revision on recompute requested', () => {
+    const state = portfolioReducer(
+      initialPortfolioState,
+      PortfolioActions.portfolioRecomputeRequested()
+    );
+    expect(state.revision).toBe(initialPortfolioState.revision + 1);
+  });
+});

--- a/boersencockpit/src/app/features/portfolio/state/portfolio.reducer.ts
+++ b/boersencockpit/src/app/features/portfolio/state/portfolio.reducer.ts
@@ -1,0 +1,21 @@
+import { createReducer, on } from '@ngrx/store';
+
+import * as PortfolioActions from './portfolio.actions';
+import { PortfolioState } from './portfolio.models';
+
+export const initialPortfolioState: PortfolioState = {
+  selectedRange: '1M',
+  revision: 0,
+};
+
+export const portfolioReducer = createReducer(
+  initialPortfolioState,
+  on(PortfolioActions.portfolioRangeChanged, (state, { range }) => ({
+    selectedRange: range,
+    revision: state.revision + 1,
+  })),
+  on(PortfolioActions.portfolioRecomputeRequested, (state) => ({
+    ...state,
+    revision: state.revision + 1,
+  }))
+);

--- a/boersencockpit/src/app/features/portfolio/state/portfolio.selectors.spec.ts
+++ b/boersencockpit/src/app/features/portfolio/state/portfolio.selectors.spec.ts
@@ -1,0 +1,54 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { PortfolioSnapshot } from '../../../domain/models/portfolio-snapshot';
+import { PriceQuote } from '../../../domain/models/quote';
+import { Position } from '../../../domain/models/position';
+import {
+  selectPortfolioMetrics,
+  selectPortfolioSnapshot,
+  selectTopFlop,
+  selectSelectedRange,
+} from './portfolio.selectors';
+import { initialPortfolioState } from './portfolio.reducer';
+
+const positions: Position[] = [
+  { symbol: asSymbol('AAPL'), totalQuantity: 5, avgBuyPrice: 100, realizedPnL: 0 },
+  { symbol: asSymbol('SAP'), totalQuantity: 3, avgBuyPrice: 80, realizedPnL: 20 },
+];
+
+const quotes: PriceQuote[] = [
+  { symbol: asSymbol('AAPL'), price: 120, changeAbs: 5, changePct: 4.35, asOf: '2024-01-01T00:00:00.000Z' },
+  { symbol: asSymbol('SAP'), price: 70, changeAbs: -2, changePct: -2.78, asOf: '2024-01-01T00:00:00.000Z' },
+];
+
+describe('portfolio selectors', () => {
+  it('selectPortfolioMetrics computes snapshot metrics', () => {
+    const snapshot = selectPortfolioMetrics.projector(positions, quotes);
+    expect(snapshot.totalValue).toBeCloseTo(5 * 120 + 3 * 70);
+    expect(snapshot.invested).toBeCloseTo(5 * 100 + 3 * 80);
+    expect(snapshot.pnlAbs).toBeCloseTo(snapshot.totalValue - snapshot.invested);
+  });
+
+  it('selectPortfolioSnapshot respects given asOf date', () => {
+    const selector = selectPortfolioSnapshot('2024-02-01T00:00:00.000Z') as unknown as {
+      projector: (positions: readonly Position[], quotes: readonly PriceQuote[]) => PortfolioSnapshot;
+    };
+    const snapshot = selector.projector(positions, quotes);
+    expect(snapshot.asOf).toBe('2024-02-01T00:00:00.000Z');
+  });
+
+  it('selectTopFlop separates winners and losers', () => {
+    const selector = selectTopFlop(1) as unknown as {
+      projector: (positions: readonly Position[], quotes: readonly PriceQuote[]) => {
+        top: readonly PriceQuote[];
+        flop: readonly PriceQuote[];
+      };
+    };
+    const result = selector.projector(positions, quotes);
+    expect(result.top[0].symbol).toEqual(asSymbol('AAPL'));
+    expect(result.flop[0].symbol).toEqual(asSymbol('SAP'));
+  });
+
+  it('selectSelectedRange returns current range', () => {
+    expect(selectSelectedRange.projector(initialPortfolioState)).toBe('1M');
+  });
+});

--- a/boersencockpit/src/app/features/portfolio/state/portfolio.selectors.ts
+++ b/boersencockpit/src/app/features/portfolio/state/portfolio.selectors.ts
@@ -1,0 +1,69 @@
+import { createFeature } from '@ngrx/store';
+import { createSelector } from '@ngrx/store';
+
+import { PORTFOLIO_FEATURE_KEY } from './portfolio.models';
+import { portfolioReducer } from './portfolio.reducer';
+import { selectPositions as selectTradePositions } from '../../trades/state/trades.selectors';
+import { selectAllQuotes, selectQuoteBySymbol } from '../../quotes/state/quotes.selectors';
+import { computeSnapshot } from '../../../domain/utils/portfolio';
+import { PortfolioSnapshot } from '../../../domain/models/portfolio-snapshot';
+import { PriceQuote } from '../../../domain/models/quote';
+import { Position } from '../../../domain/models/position';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+export const portfolioFeature = createFeature({
+  name: PORTFOLIO_FEATURE_KEY,
+  reducer: portfolioReducer,
+  extraSelectors: ({ selectPortfolioState }) => ({
+    selectSelectedRange: createSelector(selectPortfolioState, (state) => state.selectedRange),
+    selectRevision: createSelector(selectPortfolioState, (state) => state.revision),
+  }),
+});
+
+export const {
+  name: portfolioFeatureKey,
+  reducer: portfolioFeatureReducer,
+  selectPortfolioState,
+  selectSelectedRange,
+  selectRevision,
+} = portfolioFeature;
+
+export const selectPositions = selectTradePositions;
+
+export const selectPortfolioMetrics = createSelector(
+  selectPositions,
+  selectAllQuotes,
+  (positions: readonly Position[], quotes: readonly PriceQuote[]): PortfolioSnapshot => {
+    if (positions.length === 0) {
+      return {
+        asOf: '1970-01-01T00:00:00.000Z',
+        totalValue: 0,
+        invested: 0,
+        pnlAbs: 0,
+        pnlPct: 0,
+      };
+    }
+    const asOf = quotes.reduce((latest, quote) => (quote.asOf > latest ? quote.asOf : latest), '1970-01-01T00:00:00.000Z');
+    return computeSnapshot(asOf, positions, quotes);
+  }
+);
+
+export const selectPortfolioSnapshot = (asOf: string) =>
+  createSelector(selectPositions, selectAllQuotes, (positions: readonly Position[], quotes: readonly PriceQuote[]) =>
+    computeSnapshot(asOf, positions, quotes)
+  );
+
+export const selectTopFlop = (count: number) =>
+  createSelector(selectPositions, selectAllQuotes, (positions: readonly Position[], quotes: readonly PriceQuote[]) => {
+    const quoteMap = new Map<Symbol, PriceQuote>(quotes.map((quote) => [quote.symbol, quote]));
+    const relevant = positions
+      .map((position) => ({ position, quote: quoteMap.get(position.symbol) }))
+      .filter((entry): entry is { position: typeof positions[number]; quote: PriceQuote } => Boolean(entry.quote));
+
+    const sortedByChange = [...relevant].sort(
+      (a, b) => b.quote.changePct - a.quote.changePct
+    );
+    const top = sortedByChange.slice(0, count).map((entry) => entry.quote);
+    const flop = [...sortedByChange].reverse().slice(0, count).map((entry) => entry.quote);
+    return { top, flop };
+  });

--- a/boersencockpit/src/app/features/quotes/state/quotes.actions.ts
+++ b/boersencockpit/src/app/features/quotes/state/quotes.actions.ts
@@ -1,0 +1,27 @@
+import { createAction, props } from '@ngrx/store';
+
+import { SerializableError } from '../../../core/errors/serializable-error';
+import { PriceQuote } from '../../../domain/models/quote';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+export const quotesSnapshotRequested = createAction(
+  '[Quotes] Snapshot Requested',
+  props<{ readonly symbols: readonly Symbol[] }>()
+);
+
+export const quotesPollStart = createAction(
+  '[Quotes] Poll Start',
+  props<{ readonly symbols: readonly Symbol[] }>()
+);
+
+export const quotesPollStop = createAction('[Quotes] Poll Stop');
+
+export const quotesTickArrived = createAction(
+  '[Quotes] Tick Arrived',
+  props<{ readonly quotes: readonly PriceQuote[] }>()
+);
+
+export const quotesTickFailed = createAction(
+  '[Quotes] Tick Failed',
+  props<{ readonly error: SerializableError }>()
+);

--- a/boersencockpit/src/app/features/quotes/state/quotes.effects.spec.ts
+++ b/boersencockpit/src/app/features/quotes/state/quotes.effects.spec.ts
@@ -1,0 +1,135 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { ReplaySubject, Subject, firstValueFrom, take } from 'rxjs';
+import { routerNavigatedAction } from '@ngrx/router-store';
+
+import { PRICE_API } from '../../../core/api/price-api.token';
+import { PriceApiPort, ListSymbol } from '../../../core/api/price-api.port';
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { PriceQuote } from '../../../domain/models/quote';
+import { AppState } from '../../../store/app.state';
+import { initialStocksState, stocksAdapter } from '../../stocks/state/stocks.reducer';
+import { initialQuotesState } from './quotes.reducer';
+import { initialTradesState } from '../../trades/state/trades.reducer';
+import { initialTimeSeriesState } from '../../timeseries/state/timeseries.reducer';
+import { initialPortfolioState } from '../../portfolio/state/portfolio.reducer';
+import * as StocksActions from '../../stocks/state/stocks.actions';
+import * as QuotesActions from './quotes.actions';
+import { QuotesEffects } from './quotes.effects';
+
+const listSymbol: ListSymbol = { symbol: asSymbol('AAPL'), name: 'Apple', currency: 'USD' };
+const quote: PriceQuote = {
+  symbol: listSymbol.symbol,
+  price: 100,
+  changeAbs: 1,
+  changePct: 1,
+  asOf: '2024-01-01T00:00:00.000Z',
+};
+
+describe('QuotesEffects', () => {
+  let actionsSubject: ReplaySubject<unknown>;
+  let effects: QuotesEffects;
+  let store: MockStore<AppState>;
+
+  const priceApi: jest.Mocked<PriceApiPort> = {
+    listSymbols: jest.fn(),
+    getQuotes: jest.fn(),
+    getTimeSeries: jest.fn(),
+    streamQuotes: jest.fn(),
+  };
+
+  const createState = (overrides: Partial<AppState> = {}): AppState => ({
+    stocks: overrides.stocks ?? initialStocksState,
+    trades: overrides.trades ?? initialTradesState,
+    quotes: overrides.quotes ?? initialQuotesState,
+    timeseries: overrides.timeseries ?? initialTimeSeriesState,
+    portfolio: overrides.portfolio ?? initialPortfolioState,
+  });
+
+  beforeEach(() => {
+    actionsSubject = new ReplaySubject<unknown>(1);
+    TestBed.configureTestingModule({
+      providers: [
+        QuotesEffects,
+        provideMockActions(() => actionsSubject.asObservable()),
+        provideMockStore({ initialState: createState() }),
+        { provide: PRICE_API, useValue: priceApi },
+      ],
+    });
+    effects = TestBed.inject(QuotesEffects);
+    store = TestBed.inject(MockStore);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('requests snapshot after symbols load', async () => {
+    actionsSubject.next(StocksActions.loadSymbolsSucceeded({ symbols: [listSymbol] }));
+    const result = await firstValueFrom(effects.loadSnapshotOnSymbols$);
+    expect(result).toEqual(QuotesActions.quotesSnapshotRequested({ symbols: [listSymbol.symbol] }));
+  });
+
+  it('loads snapshot and emits quotes', async () => {
+    priceApi.getQuotes.mockResolvedValue([quote]);
+    actionsSubject.next(QuotesActions.quotesSnapshotRequested({ symbols: [listSymbol.symbol] }));
+    const result = await firstValueFrom(effects.snapshotRequested$);
+    expect(result).toEqual(QuotesActions.quotesTickArrived({ quotes: [quote] }));
+  });
+
+  it('emits failure for snapshot errors', async () => {
+    priceApi.getQuotes.mockRejectedValue(new Error('fail'));
+    actionsSubject.next(QuotesActions.quotesSnapshotRequested({ symbols: [listSymbol.symbol] }));
+    const result = await firstValueFrom(effects.snapshotRequested$);
+    expect(result.type).toBe(QuotesActions.quotesTickFailed.type);
+    expect((result as ReturnType<typeof QuotesActions.quotesTickFailed>).error.code).toBe('API/QUOTES_SNAPSHOT');
+  });
+
+  it('streams quotes until stopped', async () => {
+    const stream = new Subject<PriceQuote>();
+    priceApi.streamQuotes.mockReturnValue(stream.asObservable());
+    const emissions: ReturnType<typeof QuotesActions.quotesTickArrived>[] = [];
+    const subscription = effects.pollQuotes$.subscribe((value) => emissions.push(value as ReturnType<typeof QuotesActions.quotesTickArrived>));
+
+    actionsSubject.next(QuotesActions.quotesPollStart({ symbols: [listSymbol.symbol] }));
+    stream.next(quote);
+    actionsSubject.next(QuotesActions.quotesPollStop());
+    subscription.unsubscribe();
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0]).toEqual(QuotesActions.quotesTickArrived({ quotes: [quote] }));
+  });
+
+  it('stops polling on navigation away', () => {
+    const stream = new Subject<PriceQuote>();
+    priceApi.streamQuotes.mockReturnValue(stream.asObservable());
+    const emissions: ReturnType<typeof QuotesActions.quotesTickArrived>[] = [];
+    const subscription = effects.pollQuotes$.subscribe((value) => emissions.push(value as ReturnType<typeof QuotesActions.quotesTickArrived>));
+
+    actionsSubject.next(QuotesActions.quotesPollStart({ symbols: [listSymbol.symbol] }));
+    stream.next(quote);
+    const navigation = routerNavigatedAction({
+      payload: {
+        event: { id: 1, url: '/portfolio', urlAfterRedirects: '/settings' } as any,
+        routerState: {} as any,
+      },
+    });
+    actionsSubject.next(navigation);
+    subscription.unsubscribe();
+
+    expect(emissions).toHaveLength(1);
+  });
+
+  it('restarts polling when watchlist diverges from polling symbols', async () => {
+    const stocksState = stocksAdapter.setAll([listSymbol], {
+      ...initialStocksState,
+      watchlist: [listSymbol.symbol],
+    });
+    const quotesState = { ...initialQuotesState, pollingSymbols: [] };
+    store.setState(createState({ stocks: stocksState, quotes: quotesState }));
+
+    const result = await firstValueFrom(effects.restartPollingOnWatchlistChange$.pipe(take(1)));
+    expect(result).toEqual(QuotesActions.quotesPollStart({ symbols: [listSymbol.symbol] }));
+  });
+});

--- a/boersencockpit/src/app/features/quotes/state/quotes.effects.ts
+++ b/boersencockpit/src/app/features/quotes/state/quotes.effects.ts
@@ -1,0 +1,127 @@
+import { inject, Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { routerNavigatedAction } from '@ngrx/router-store';
+import { Store } from '@ngrx/store';
+import { EMPTY, from, merge, of } from 'rxjs';
+import { catchError, filter, map, switchMap, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { retry } from 'rxjs';
+
+import { PRICE_API } from '../../../core/api/price-api.token';
+import { serializeError } from '../../../core/errors/serializable-error';
+import * as QuotesActions from './quotes.actions';
+import * as StocksActions from '../../stocks/state/stocks.actions';
+import { selectAllStocks, selectWatchedSymbols } from '../../stocks/state/stocks.selectors';
+import { selectPollingSymbols } from './quotes.selectors';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+@Injectable()
+export class QuotesEffects {
+  private readonly actions$ = inject(Actions);
+  private readonly store = inject(Store);
+  private readonly priceApi = inject(PRICE_API);
+
+  readonly loadSnapshotOnSymbols$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(StocksActions.loadSymbolsSucceeded),
+      map(({ symbols }) => symbols.map((item) => item.symbol)),
+      filter((symbols) => symbols.length > 0),
+      map((symbols) => QuotesActions.quotesSnapshotRequested({ symbols }))
+    )
+  );
+
+  readonly loadSnapshotOnNavigation$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(routerNavigatedAction),
+      map((action) => action.payload.event.urlAfterRedirects),
+      filter((url) => isMarketAwareRoute(url)),
+      withLatestFrom(
+        this.store.select(selectWatchedSymbols),
+        this.store.select(selectAllStocks)
+      ),
+      map(([, watchlist, stocks]) => (watchlist.length > 0 ? watchlist : stocks.map((stock) => stock.symbol))),
+      map((symbols) => ensureUniqueSymbols(symbols)),
+      filter((symbols) => symbols.length > 0),
+      map((symbols) => QuotesActions.quotesSnapshotRequested({ symbols }))
+    )
+  );
+
+  readonly snapshotRequested$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(QuotesActions.quotesSnapshotRequested),
+      map(({ symbols }) => ensureUniqueSymbols(symbols)),
+      filter((symbols) => symbols.length > 0),
+      switchMap((symbols) =>
+        from(this.priceApi.getQuotes(symbols)).pipe(
+          map((quotes) => QuotesActions.quotesTickArrived({ quotes })),
+          catchError((error) =>
+            of(
+              QuotesActions.quotesTickFailed({
+                error: serializeError(error, 'API/QUOTES_SNAPSHOT'),
+              })
+            )
+          )
+        )
+      )
+    )
+  );
+
+  readonly pollQuotes$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(QuotesActions.quotesPollStart),
+      map(({ symbols }) => ensureUniqueSymbols(symbols)),
+      switchMap((symbols) => {
+        if (symbols.length === 0) {
+          return EMPTY;
+        }
+        const stop$ = merge(
+          this.actions$.pipe(ofType(QuotesActions.quotesPollStop)),
+          this.actions$.pipe(
+            ofType(routerNavigatedAction),
+            filter((action) => !isMarketAwareRoute(action.payload.event.urlAfterRedirects))
+          )
+        );
+        return this.priceApi.streamQuotes(symbols).pipe(
+          retry({ count: 3, delay: 1000 }),
+          map((quote) => QuotesActions.quotesTickArrived({ quotes: [quote] })),
+          takeUntil(stop$),
+          catchError((error) =>
+            of(
+              QuotesActions.quotesTickFailed({
+                error: serializeError(error, 'API/QUOTES_STREAM'),
+              })
+            )
+          )
+        );
+      })
+    )
+  );
+
+  readonly restartPollingOnWatchlistChange$ = createEffect(() =>
+    this.store.select(selectWatchedSymbols).pipe(
+      withLatestFrom(this.store.select(selectPollingSymbols)),
+      map(([watchlist, pollingSymbols]) => ({ watchlist: ensureUniqueSymbols(watchlist), pollingSymbols })),
+      filter(({ watchlist, pollingSymbols }) =>
+        watchlist.length > 0 &&
+        (pollingSymbols.length !== watchlist.length || !pollingSymbols.every((symbol) => watchlist.includes(symbol)))
+      ),
+      map(({ watchlist }) => QuotesActions.quotesPollStart({ symbols: watchlist }))
+    )
+  );
+
+  readonly stopPollingWhenEmptyWatchlist$ = createEffect(() =>
+    this.store.select(selectWatchedSymbols).pipe(
+      withLatestFrom(this.store.select(selectPollingSymbols)),
+      map(([watchlist, pollingSymbols]) => ({
+        watchlist: ensureUniqueSymbols(watchlist),
+        pollingSymbols,
+      })),
+      filter(({ watchlist, pollingSymbols }) => watchlist.length === 0 && pollingSymbols.length > 0),
+      map(() => QuotesActions.quotesPollStop())
+    )
+  );
+}
+
+const isMarketAwareRoute = (url: string): boolean => /^(\/portfolio|\/stocks)/.test(url);
+
+const ensureUniqueSymbols = (symbols: readonly Symbol[]): readonly Symbol[] =>
+  Array.from(new Set(symbols)).sort((a, b) => a.localeCompare(b)) as readonly Symbol[];

--- a/boersencockpit/src/app/features/quotes/state/quotes.models.ts
+++ b/boersencockpit/src/app/features/quotes/state/quotes.models.ts
@@ -1,0 +1,15 @@
+import { EntityState } from '@ngrx/entity';
+
+import { SerializableError } from '../../../core/errors/serializable-error';
+import { PriceQuote } from '../../../domain/models/quote';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+export interface QuotesState extends EntityState<PriceQuote> {
+  readonly loading: boolean;
+  readonly polling: boolean;
+  readonly pollingSymbols: readonly Symbol[];
+  readonly error: SerializableError | null;
+  readonly lastUpdated?: string;
+}
+
+export const QUOTES_FEATURE_KEY = 'quotes';

--- a/boersencockpit/src/app/features/quotes/state/quotes.reducer.spec.ts
+++ b/boersencockpit/src/app/features/quotes/state/quotes.reducer.spec.ts
@@ -1,0 +1,44 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { PriceQuote } from '../../../domain/models/quote';
+import { serializeError } from '../../../core/errors/serializable-error';
+import * as QuotesActions from './quotes.actions';
+import { initialQuotesState, quotesReducer } from './quotes.reducer';
+
+describe('quotesReducer', () => {
+  const quote: PriceQuote = {
+    symbol: asSymbol('AAPL'),
+    price: 100,
+    changeAbs: 1,
+    changePct: 1,
+    asOf: '2024-01-01T00:00:00.000Z',
+  };
+
+  it('returns initial state for unknown action', () => {
+    const state = quotesReducer(undefined, { type: 'Unknown' });
+    expect(state).toEqual(initialQuotesState);
+  });
+
+  it('sets loading on snapshot requested', () => {
+    const state = quotesReducer(initialQuotesState, QuotesActions.quotesSnapshotRequested({ symbols: [quote.symbol] }));
+    expect(state.loading).toBe(true);
+    expect(state.pollingSymbols).toContain(quote.symbol);
+  });
+
+  it('starts polling on poll start', () => {
+    const state = quotesReducer(initialQuotesState, QuotesActions.quotesPollStart({ symbols: [quote.symbol] }));
+    expect(state.polling).toBe(true);
+  });
+
+  it('upserts quotes on tick', () => {
+    const state = quotesReducer(initialQuotesState, QuotesActions.quotesTickArrived({ quotes: [quote] }));
+    expect(state.entities[quote.symbol]).toEqual(quote);
+    expect(state.loading).toBe(false);
+    expect(state.lastUpdated).toEqual(quote.asOf);
+  });
+
+  it('stores error on failure', () => {
+    const error = serializeError(new Error('failed'), 'TEST');
+    const state = quotesReducer(initialQuotesState, QuotesActions.quotesTickFailed({ error }));
+    expect(state.error).toEqual(error);
+  });
+});

--- a/boersencockpit/src/app/features/quotes/state/quotes.reducer.ts
+++ b/boersencockpit/src/app/features/quotes/state/quotes.reducer.ts
@@ -1,0 +1,58 @@
+import { createEntityAdapter } from '@ngrx/entity';
+import { createReducer, on } from '@ngrx/store';
+
+import { PriceQuote } from '../../../domain/models/quote';
+import { Symbol } from '../../../domain/models/symbol.brand';
+import * as QuotesActions from './quotes.actions';
+import { QuotesState } from './quotes.models';
+
+export const quotesAdapter = createEntityAdapter<PriceQuote>({
+  selectId: (quote) => quote.symbol,
+  sortComparer: (a, b) => a.symbol.localeCompare(b.symbol),
+});
+
+export const initialQuotesState: QuotesState = quotesAdapter.getInitialState({
+  loading: false,
+  polling: false,
+  pollingSymbols: [],
+  error: null,
+  lastUpdated: undefined,
+});
+
+export const quotesReducer = createReducer(
+  initialQuotesState,
+  on(QuotesActions.quotesSnapshotRequested, (state, { symbols }) => ({
+    ...state,
+    loading: true,
+    error: null,
+    pollingSymbols: ensureSymbolsUnique(symbols),
+  })),
+  on(QuotesActions.quotesPollStart, (state, { symbols }) => ({
+    ...state,
+    polling: true,
+    pollingSymbols: ensureSymbolsUnique(symbols),
+    error: null,
+  })),
+  on(QuotesActions.quotesPollStop, (state) => ({
+    ...state,
+    polling: false,
+    pollingSymbols: [],
+  })),
+  on(QuotesActions.quotesTickArrived, (state, { quotes }) =>
+    quotesAdapter.upsertMany([...quotes], {
+      ...state,
+      loading: false,
+      lastUpdated: quotes.length
+        ? quotes.map((quote) => quote.asOf).sort().slice(-1)[0]
+        : state.lastUpdated,
+    })
+  ),
+  on(QuotesActions.quotesTickFailed, (state, { error }) => ({
+    ...state,
+    loading: false,
+    error,
+  }))
+);
+
+const ensureSymbolsUnique = (symbols: readonly Symbol[]): readonly Symbol[] =>
+  Array.from(new Set(symbols)).sort((a, b) => a.localeCompare(b)) as readonly Symbol[];

--- a/boersencockpit/src/app/features/quotes/state/quotes.selectors.spec.ts
+++ b/boersencockpit/src/app/features/quotes/state/quotes.selectors.spec.ts
@@ -1,0 +1,47 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { PriceQuote } from '../../../domain/models/quote';
+import { quotesAdapter, initialQuotesState } from './quotes.reducer';
+import {
+  selectAllQuotes,
+  selectQuoteBySymbol,
+  selectPositiveSymbols,
+  selectNegativeSymbols,
+  selectTopMovers,
+} from './quotes.selectors';
+
+const quotes: PriceQuote[] = [
+  { symbol: asSymbol('AAPL'), price: 100, changeAbs: 1, changePct: 1, asOf: '2024-01-01T00:00:00.000Z' },
+  { symbol: asSymbol('SAP'), price: 90, changeAbs: -2, changePct: -2.2, asOf: '2024-01-01T00:00:00.000Z' },
+  { symbol: asSymbol('MSFT'), price: 150, changeAbs: 5, changePct: 3, asOf: '2024-01-01T00:00:00.000Z' },
+];
+
+describe('quotes selectors', () => {
+  const state = quotesAdapter.setAll(quotes, initialQuotesState);
+  const rootState = { quotes: state } as { quotes: typeof state };
+
+  it('selectAllQuotes returns sorted quotes', () => {
+    expect(selectAllQuotes.projector(state)[0].symbol).toEqual(asSymbol('AAPL'));
+  });
+
+  it('selectQuoteBySymbol returns quote', () => {
+    const selector = selectQuoteBySymbol(asSymbol('SAP'));
+    expect(selector(rootState)).toEqual(quotes[1]);
+  });
+
+  it('selectPositiveSymbols returns only positive movers', () => {
+    expect(selectPositiveSymbols.projector(quotes)).toEqual([
+      asSymbol('AAPL'),
+      asSymbol('MSFT'),
+    ]);
+  });
+
+  it('selectNegativeSymbols returns only negative movers', () => {
+    expect(selectNegativeSymbols.projector(quotes)).toEqual([asSymbol('SAP')]);
+  });
+
+  it('selectTopMovers returns top movers by change percentage', () => {
+    const selector = selectTopMovers(2);
+    const result = selector(rootState);
+    expect(result.map((quote) => quote.symbol)).toEqual([asSymbol('MSFT'), asSymbol('SAP')]);
+  });
+});

--- a/boersencockpit/src/app/features/quotes/state/quotes.selectors.ts
+++ b/boersencockpit/src/app/features/quotes/state/quotes.selectors.ts
@@ -1,0 +1,40 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+
+import { QUOTES_FEATURE_KEY, QuotesState } from './quotes.models';
+import { quotesAdapter, quotesReducer } from './quotes.reducer';
+import { Symbol } from '../../../domain/models/symbol.brand';
+import { PriceQuote } from '../../../domain/models/quote';
+
+const { selectAll, selectEntities } = quotesAdapter.getSelectors();
+
+export const quotesFeatureKey = QUOTES_FEATURE_KEY;
+export const quotesFeatureReducer = quotesReducer;
+
+export const selectQuotesState = createFeatureSelector<QuotesState>(QUOTES_FEATURE_KEY);
+
+export const selectAllQuotes = createSelector(selectQuotesState, (state) => selectAll(state));
+
+export const selectQuotesEntities = createSelector(selectQuotesState, (state) => selectEntities(state));
+
+export const selectPollingSymbols = createSelector(
+  selectQuotesState,
+  (state) => state.pollingSymbols
+);
+
+export const selectQuoteBySymbol = (symbol: Symbol) =>
+  createSelector(selectQuotesEntities, (entities) => entities[symbol]);
+
+export const selectPositiveSymbols = createSelector(selectAllQuotes, (quotes) =>
+  quotes.filter((quote: PriceQuote) => quote.changePct > 0).map((quote) => quote.symbol)
+);
+
+export const selectNegativeSymbols = createSelector(selectAllQuotes, (quotes) =>
+  quotes.filter((quote: PriceQuote) => quote.changePct < 0).map((quote) => quote.symbol)
+);
+
+export const selectTopMovers = (count: number) =>
+  createSelector(selectAllQuotes, (quotes) =>
+    [...quotes]
+      .sort((a, b) => Math.abs(b.changePct) - Math.abs(a.changePct))
+      .slice(0, count)
+  );

--- a/boersencockpit/src/app/features/stocks/state/stocks.actions.ts
+++ b/boersencockpit/src/app/features/stocks/state/stocks.actions.ts
@@ -1,0 +1,27 @@
+import { createAction, props } from '@ngrx/store';
+
+import { ListSymbol } from '../../../core/api/price-api.port';
+import { SerializableError } from '../../../core/errors/serializable-error';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+export const loadSymbolsRequested = createAction('[Stocks] Load Symbols Requested');
+
+export const loadSymbolsSucceeded = createAction(
+  '[Stocks] Load Symbols Succeeded',
+  props<{ readonly symbols: readonly ListSymbol[] }>()
+);
+
+export const loadSymbolsFailed = createAction(
+  '[Stocks] Load Symbols Failed',
+  props<{ readonly error: SerializableError }>()
+);
+
+export const watchSymbolRequested = createAction(
+  '[Stocks] Watch Symbol Requested',
+  props<{ readonly symbol: Symbol }>()
+);
+
+export const unwatchSymbolRequested = createAction(
+  '[Stocks] Unwatch Symbol Requested',
+  props<{ readonly symbol: Symbol }>()
+);

--- a/boersencockpit/src/app/features/stocks/state/stocks.effects.spec.ts
+++ b/boersencockpit/src/app/features/stocks/state/stocks.effects.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { ReplaySubject, firstValueFrom } from 'rxjs';
+
+import { PRICE_API } from '../../../core/api/price-api.token';
+import { PriceApiPort, ListSymbol } from '../../../core/api/price-api.port';
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import * as StocksActions from './stocks.actions';
+import { StocksEffects } from './stocks.effects';
+
+describe('StocksEffects', () => {
+  let actionsSubject: ReplaySubject<unknown>;
+  let effects: StocksEffects;
+
+  const priceApi: jest.Mocked<PriceApiPort> = {
+    listSymbols: jest.fn(),
+    getQuotes: jest.fn(),
+    getTimeSeries: jest.fn(),
+    streamQuotes: jest.fn(),
+  };
+
+  const sampleSymbols: ListSymbol[] = [
+    { symbol: asSymbol('AAPL'), name: 'Apple', currency: 'USD' },
+  ];
+
+  beforeEach(() => {
+    actionsSubject = new ReplaySubject<unknown>(1);
+    TestBed.configureTestingModule({
+      providers: [
+        StocksEffects,
+        provideMockActions(() => actionsSubject.asObservable()),
+        { provide: PRICE_API, useValue: priceApi },
+      ],
+    });
+    effects = TestBed.inject(StocksEffects);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('emits success when symbols load', async () => {
+    priceApi.listSymbols.mockResolvedValue(sampleSymbols);
+    actionsSubject.next(StocksActions.loadSymbolsRequested());
+    const result = await firstValueFrom(effects.loadSymbolsRequested$);
+    expect(result).toEqual(StocksActions.loadSymbolsSucceeded({ symbols: sampleSymbols }));
+  });
+
+  it('emits failure when symbols load fails', async () => {
+    priceApi.listSymbols.mockRejectedValue(new Error('boom'));
+    actionsSubject.next(StocksActions.loadSymbolsRequested());
+    const result = await firstValueFrom(effects.loadSymbolsRequested$);
+    expect(result.type).toBe(StocksActions.loadSymbolsFailed.type);
+    expect((result as ReturnType<typeof StocksActions.loadSymbolsFailed>).error.code).toBe('API/STOCKS');
+  });
+});

--- a/boersencockpit/src/app/features/stocks/state/stocks.effects.ts
+++ b/boersencockpit/src/app/features/stocks/state/stocks.effects.ts
@@ -1,0 +1,32 @@
+import { inject, Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { from, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+
+import { PRICE_API } from '../../../core/api/price-api.token';
+import { serializeError } from '../../../core/errors/serializable-error';
+import * as StocksActions from './stocks.actions';
+
+@Injectable()
+export class StocksEffects {
+  private readonly actions$ = inject(Actions);
+  private readonly priceApi = inject(PRICE_API);
+
+  readonly loadSymbolsRequested$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(StocksActions.loadSymbolsRequested),
+      switchMap(() =>
+        from(this.priceApi.listSymbols()).pipe(
+          map((symbols) => StocksActions.loadSymbolsSucceeded({ symbols })),
+          catchError((error) =>
+            of(
+              StocksActions.loadSymbolsFailed({
+                error: serializeError(error, 'API/STOCKS'),
+              })
+            )
+          )
+        )
+      )
+    )
+  );
+}

--- a/boersencockpit/src/app/features/stocks/state/stocks.models.ts
+++ b/boersencockpit/src/app/features/stocks/state/stocks.models.ts
@@ -1,0 +1,14 @@
+import { EntityState } from '@ngrx/entity';
+
+import { ListSymbol } from '../../../core/api/price-api.port';
+import { SerializableError } from '../../../core/errors/serializable-error';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+export interface StocksState extends EntityState<ListSymbol> {
+  readonly loading: boolean;
+  readonly loaded: boolean;
+  readonly error: SerializableError | null;
+  readonly watchlist: readonly Symbol[];
+}
+
+export const STOCKS_FEATURE_KEY = 'stocks';

--- a/boersencockpit/src/app/features/stocks/state/stocks.reducer.spec.ts
+++ b/boersencockpit/src/app/features/stocks/state/stocks.reducer.spec.ts
@@ -1,0 +1,44 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { ListSymbol } from '../../../core/api/price-api.port';
+import { serializeError } from '../../../core/errors/serializable-error';
+import * as StocksActions from './stocks.actions';
+import { initialStocksState, stocksReducer } from './stocks.reducer';
+
+const sampleSymbols: ListSymbol[] = [
+  { symbol: asSymbol('AAPL'), name: 'Apple', currency: 'USD' },
+  { symbol: asSymbol('SAP'), name: 'SAP', currency: 'EUR' },
+];
+
+describe('stocksReducer', () => {
+  it('should return the initial state for unknown action', () => {
+    const state = stocksReducer(undefined, { type: 'Unknown' });
+    expect(state).toEqual(initialStocksState);
+  });
+
+  it('should set loading on loadSymbolsRequested', () => {
+    const state = stocksReducer(initialStocksState, StocksActions.loadSymbolsRequested());
+    expect(state.loading).toBe(true);
+  });
+
+  it('should populate symbols on loadSymbolsSucceeded', () => {
+    const state = stocksReducer(initialStocksState, StocksActions.loadSymbolsSucceeded({ symbols: sampleSymbols }));
+    expect(state.loading).toBe(false);
+    expect(state.entities[sampleSymbols[0].symbol]).toEqual(sampleSymbols[0]);
+    expect(state.watchlist).toEqual(sampleSymbols.map((item) => item.symbol));
+  });
+
+  it('should store error on loadSymbolsFailed', () => {
+    const error = serializeError(new Error('fail'), 'TEST/ERROR');
+    const state = stocksReducer(initialStocksState, StocksActions.loadSymbolsFailed({ error }));
+    expect(state.error).toEqual(error);
+    expect(state.loading).toBe(false);
+  });
+
+  it('should add and remove symbols from watchlist', () => {
+    const loadedState = stocksReducer(initialStocksState, StocksActions.loadSymbolsSucceeded({ symbols: sampleSymbols }));
+    const afterUnwatch = stocksReducer(loadedState, StocksActions.unwatchSymbolRequested({ symbol: sampleSymbols[0].symbol }));
+    expect(afterUnwatch.watchlist).not.toContain(sampleSymbols[0].symbol);
+    const afterWatch = stocksReducer(afterUnwatch, StocksActions.watchSymbolRequested({ symbol: sampleSymbols[0].symbol }));
+    expect(afterWatch.watchlist).toContain(sampleSymbols[0].symbol);
+  });
+});

--- a/boersencockpit/src/app/features/stocks/state/stocks.reducer.ts
+++ b/boersencockpit/src/app/features/stocks/state/stocks.reducer.ts
@@ -1,0 +1,60 @@
+import { createEntityAdapter } from '@ngrx/entity';
+import { createReducer, on } from '@ngrx/store';
+
+import { ListSymbol } from '../../../core/api/price-api.port';
+import { Symbol } from '../../../domain/models/symbol.brand';
+import { StocksState } from './stocks.models';
+import * as StocksActions from './stocks.actions';
+
+export const stocksAdapter = createEntityAdapter<ListSymbol>({
+  selectId: (symbol) => symbol.symbol,
+  sortComparer: (a, b) => a.symbol.localeCompare(b.symbol),
+});
+
+export const initialStocksState: StocksState = stocksAdapter.getInitialState({
+  loading: false,
+  loaded: false,
+  error: null,
+  watchlist: [],
+});
+
+export const stocksReducer = createReducer(
+  initialStocksState,
+  on(StocksActions.loadSymbolsRequested, (state) => ({
+    ...state,
+    loading: true,
+    error: null,
+  })),
+  on(StocksActions.loadSymbolsSucceeded, (state, { symbols }) =>
+    stocksAdapter.setAll([...symbols], {
+      ...state,
+      loading: false,
+      loaded: true,
+      watchlist: symbols.map<Symbol>((item) => item.symbol),
+    })
+  ),
+  on(StocksActions.loadSymbolsFailed, (state, { error }) => ({
+    ...state,
+    loading: false,
+    error,
+  })),
+  on(StocksActions.watchSymbolRequested, (state, { symbol }) => ({
+    ...state,
+    watchlist: addToWatchlist(state.watchlist, symbol),
+  })),
+  on(StocksActions.unwatchSymbolRequested, (state, { symbol }) => ({
+    ...state,
+    watchlist: removeFromWatchlist(state.watchlist, symbol),
+  }))
+);
+
+const addToWatchlist = (watchlist: readonly Symbol[], symbol: Symbol): readonly Symbol[] => {
+  if (watchlist.includes(symbol)) {
+    return watchlist;
+  }
+  return [...watchlist, symbol].sort((a, b) => a.localeCompare(b)) as readonly Symbol[];
+};
+
+const removeFromWatchlist = (watchlist: readonly Symbol[], symbol: Symbol): readonly Symbol[] =>
+  watchlist.filter((entry) => entry !== symbol);
+

--- a/boersencockpit/src/app/features/stocks/state/stocks.selectors.spec.ts
+++ b/boersencockpit/src/app/features/stocks/state/stocks.selectors.spec.ts
@@ -1,0 +1,31 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { ListSymbol } from '../../../core/api/price-api.port';
+import { stocksAdapter, initialStocksState } from './stocks.reducer';
+import { selectAllStocks, selectStockBySymbol, selectWatchlist } from './stocks.selectors';
+
+const sampleSymbols: ListSymbol[] = [
+  { symbol: asSymbol('AAPL'), name: 'Apple', currency: 'USD' },
+  { symbol: asSymbol('SAP'), name: 'SAP', currency: 'EUR' },
+];
+
+describe('stocks selectors', () => {
+  const state = stocksAdapter.setAll(sampleSymbols, {
+    ...initialStocksState,
+    watchlist: sampleSymbols.map((item) => item.symbol),
+  });
+
+  const rootState = { stocks: state } as { stocks: typeof state };
+
+  it('selectAllStocks returns ordered list', () => {
+    expect(selectAllStocks.projector(state)).toEqual(sampleSymbols);
+  });
+
+  it('selectStockBySymbol returns entity', () => {
+    const selector = selectStockBySymbol(sampleSymbols[0].symbol);
+    expect(selector(rootState)).toEqual(sampleSymbols[0]);
+  });
+
+  it('selectWatchlist returns all watched symbols', () => {
+    expect(selectWatchlist.projector(state)).toEqual(sampleSymbols.map((item) => item.symbol));
+  });
+});

--- a/boersencockpit/src/app/features/stocks/state/stocks.selectors.ts
+++ b/boersencockpit/src/app/features/stocks/state/stocks.selectors.ts
@@ -1,0 +1,32 @@
+import { createSelector } from '@ngrx/store';
+import { createFeature } from '@ngrx/store';
+
+import { STOCKS_FEATURE_KEY } from './stocks.models';
+import { stocksAdapter, stocksReducer } from './stocks.reducer';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+const { selectAll, selectEntities } = stocksAdapter.getSelectors();
+
+export const stocksFeature = createFeature({
+  name: STOCKS_FEATURE_KEY,
+  reducer: stocksReducer,
+  extraSelectors: ({ selectStocksState }) => ({
+    selectAllStocks: createSelector(selectStocksState, selectAll),
+    selectStockEntities: createSelector(selectStocksState, selectEntities),
+    selectWatchlist: createSelector(selectStocksState, (state) => state.watchlist),
+    selectWatchedSymbols: createSelector(selectStocksState, (state) => state.watchlist),
+  }),
+});
+
+export const {
+  name: stocksFeatureKey,
+  reducer: stocksFeatureReducer,
+  selectStocksState,
+  selectAllStocks,
+  selectStockEntities,
+  selectWatchlist,
+  selectWatchedSymbols,
+} = stocksFeature;
+
+export const selectStockBySymbol = (symbol: Symbol) =>
+  createSelector(selectStockEntities, (entities) => entities[symbol]);

--- a/boersencockpit/src/app/features/timeseries/state/timeseries.actions.ts
+++ b/boersencockpit/src/app/features/timeseries/state/timeseries.actions.ts
@@ -1,0 +1,26 @@
+import { createAction, props } from '@ngrx/store';
+
+import { SerializableError } from '../../../core/errors/serializable-error';
+import { RangeKey } from '../../../core/api/price-api.port';
+import { TimeSeries } from '../../../domain/models/candle';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+export const timeSeriesRequested = createAction(
+  '[TimeSeries] Load Requested',
+  props<{ readonly symbol: Symbol; readonly range: RangeKey }>()
+);
+
+export const timeSeriesSucceeded = createAction(
+  '[TimeSeries] Load Succeeded',
+  props<{ readonly symbol: Symbol; readonly range: RangeKey; readonly series: TimeSeries }>()
+);
+
+export const timeSeriesFailed = createAction(
+  '[TimeSeries] Load Failed',
+  props<{ readonly symbol: Symbol; readonly range: RangeKey; readonly error: SerializableError }>()
+);
+
+export const timeSeriesEvictRange = createAction(
+  '[TimeSeries] Evict Range',
+  props<{ readonly symbol: Symbol; readonly range: RangeKey }>()
+);

--- a/boersencockpit/src/app/features/timeseries/state/timeseries.effects.spec.ts
+++ b/boersencockpit/src/app/features/timeseries/state/timeseries.effects.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { ReplaySubject, firstValueFrom } from 'rxjs';
+
+import { PRICE_API } from '../../../core/api/price-api.token';
+import { PriceApiPort } from '../../../core/api/price-api.port';
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { TimeSeries } from '../../../domain/models/candle';
+import { AppState } from '../../../store/app.state';
+import { initialStocksState } from '../../stocks/state/stocks.reducer';
+import { initialQuotesState } from '../../quotes/state/quotes.reducer';
+import { initialTradesState } from '../../trades/state/trades.reducer';
+import { initialPortfolioState } from '../../portfolio/state/portfolio.reducer';
+import { initialTimeSeriesState } from './timeseries.reducer';
+import * as TimeSeriesActions from './timeseries.actions';
+import { TimeSeriesEffects } from './timeseries.effects';
+
+const symbol = asSymbol('AAPL');
+const range = '1M' as const;
+const series: TimeSeries = {
+  symbol,
+  candles: [{ t: '2024-01-01T00:00:00.000Z', o: 1, h: 1, l: 1, c: 1 }],
+};
+
+describe('TimeSeriesEffects', () => {
+  let actionsSubject: ReplaySubject<unknown>;
+  let effects: TimeSeriesEffects;
+  let store: MockStore<AppState>;
+
+  const priceApi: jest.Mocked<PriceApiPort> = {
+    listSymbols: jest.fn(),
+    getQuotes: jest.fn(),
+    getTimeSeries: jest.fn(),
+    streamQuotes: jest.fn(),
+  };
+
+  const createState = (overrides: Partial<AppState> = {}): AppState => ({
+    stocks: overrides.stocks ?? initialStocksState,
+    trades: overrides.trades ?? initialTradesState,
+    quotes: overrides.quotes ?? initialQuotesState,
+    timeseries: overrides.timeseries ?? initialTimeSeriesState,
+    portfolio: overrides.portfolio ?? initialPortfolioState,
+  });
+
+  beforeEach(() => {
+    actionsSubject = new ReplaySubject<unknown>(1);
+    TestBed.configureTestingModule({
+      providers: [
+        TimeSeriesEffects,
+        provideMockActions(() => actionsSubject.asObservable()),
+        provideMockStore({ initialState: createState() }),
+        { provide: PRICE_API, useValue: priceApi },
+      ],
+    });
+    effects = TestBed.inject(TimeSeriesEffects);
+    store = TestBed.inject(MockStore);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('loads series when cache miss', async () => {
+    priceApi.getTimeSeries.mockResolvedValue(series);
+    actionsSubject.next(TimeSeriesActions.timeSeriesRequested({ symbol, range }));
+    const result = await firstValueFrom(effects.loadTimeSeries$);
+    expect(result).toEqual(TimeSeriesActions.timeSeriesSucceeded({ symbol, range, series }));
+  });
+
+  it('does not load series when cached', () => {
+    const cachedState = {
+      ...initialTimeSeriesState,
+      series: { [symbol]: { [range]: series } },
+      loading: { [symbol]: { [range]: false } },
+    };
+    store.setState(createState({ timeseries: cachedState }));
+    const emissions: unknown[] = [];
+    const subscription = effects.loadTimeSeries$.subscribe((value) => emissions.push(value));
+    actionsSubject.next(TimeSeriesActions.timeSeriesRequested({ symbol, range }));
+    actionsSubject.complete();
+    subscription.unsubscribe();
+    expect(emissions).toHaveLength(0);
+    expect(priceApi.getTimeSeries).not.toHaveBeenCalled();
+  });
+
+  it('emits failure on error', async () => {
+    priceApi.getTimeSeries.mockRejectedValue(new Error('fail'));
+    actionsSubject.next(TimeSeriesActions.timeSeriesRequested({ symbol, range }));
+    const result = await firstValueFrom(effects.loadTimeSeries$);
+    expect(result.type).toBe(TimeSeriesActions.timeSeriesFailed.type);
+    expect((result as ReturnType<typeof TimeSeriesActions.timeSeriesFailed>).error.code).toBe('API/TIMESERIES');
+  });
+});

--- a/boersencockpit/src/app/features/timeseries/state/timeseries.effects.ts
+++ b/boersencockpit/src/app/features/timeseries/state/timeseries.effects.ts
@@ -1,0 +1,47 @@
+import { inject, Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { combineLatest, EMPTY, from, of } from 'rxjs';
+import { catchError, concatMap, map, switchMap, take } from 'rxjs/operators';
+
+import { PRICE_API } from '../../../core/api/price-api.token';
+import { serializeError } from '../../../core/errors/serializable-error';
+import * as TimeSeriesActions from './timeseries.actions';
+import { selectHasTimeSeries, selectTimeSeriesLoading } from './timeseries.selectors';
+
+@Injectable()
+export class TimeSeriesEffects {
+  private readonly actions$ = inject(Actions);
+  private readonly store = inject(Store);
+  private readonly priceApi = inject(PRICE_API);
+
+  readonly loadTimeSeries$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TimeSeriesActions.timeSeriesRequested),
+      concatMap(({ symbol, range }) =>
+        combineLatest([
+          this.store.select(selectHasTimeSeries(symbol, range)).pipe(take(1)),
+          this.store.select(selectTimeSeriesLoading(symbol, range)).pipe(take(1)),
+        ]).pipe(
+          switchMap(([hasSeries, isLoading]) => {
+            if (hasSeries || isLoading) {
+              return EMPTY;
+            }
+            return from(this.priceApi.getTimeSeries(symbol, range)).pipe(
+              map((series) => TimeSeriesActions.timeSeriesSucceeded({ symbol, range, series })),
+              catchError((error) =>
+                of(
+                  TimeSeriesActions.timeSeriesFailed({
+                    symbol,
+                    range,
+                    error: serializeError(error, 'API/TIMESERIES'),
+                  })
+                )
+              )
+            );
+          })
+        )
+      )
+    )
+  );
+}

--- a/boersencockpit/src/app/features/timeseries/state/timeseries.models.ts
+++ b/boersencockpit/src/app/features/timeseries/state/timeseries.models.ts
@@ -1,0 +1,14 @@
+import { RangeKey } from '../../../core/api/price-api.port';
+import { SerializableError } from '../../../core/errors/serializable-error';
+import { TimeSeries } from '../../../domain/models/candle';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+export type RangeStateMap<T> = Readonly<Record<RangeKey, T>>;
+
+export interface TimeSeriesState {
+  readonly series: Readonly<Record<Symbol, Partial<Record<RangeKey, TimeSeries>>>>;
+  readonly loading: Readonly<Record<Symbol, Partial<Record<RangeKey, boolean>>>>;
+  readonly errors: Readonly<Record<Symbol, Partial<Record<RangeKey, SerializableError | null>>>>;
+}
+
+export const TIMESERIES_FEATURE_KEY = 'timeseries';

--- a/boersencockpit/src/app/features/timeseries/state/timeseries.reducer.spec.ts
+++ b/boersencockpit/src/app/features/timeseries/state/timeseries.reducer.spec.ts
@@ -1,0 +1,56 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { TimeSeries } from '../../../domain/models/candle';
+import { serializeError } from '../../../core/errors/serializable-error';
+import * as TimeSeriesActions from './timeseries.actions';
+import { initialTimeSeriesState, timeSeriesReducer } from './timeseries.reducer';
+
+const symbol = asSymbol('AAPL');
+const range = '1M' as const;
+const series: TimeSeries = {
+  symbol,
+  candles: [
+    { t: '2024-01-01T00:00:00.000Z', o: 1, h: 2, l: 0.5, c: 1.5 },
+    { t: '2024-01-02T00:00:00.000Z', o: 1.5, h: 2, l: 1, c: 1.8 },
+  ],
+};
+
+describe('timeSeriesReducer', () => {
+  it('returns initial state for unknown action', () => {
+    const state = timeSeriesReducer(undefined, { type: 'Unknown' });
+    expect(state).toEqual(initialTimeSeriesState);
+  });
+
+  it('sets loading on request', () => {
+    const state = timeSeriesReducer(
+      initialTimeSeriesState,
+      TimeSeriesActions.timeSeriesRequested({ symbol, range })
+    );
+    expect(state.loading[symbol]?.[range]).toBe(true);
+  });
+
+  it('stores series on success', () => {
+    const state = timeSeriesReducer(
+      initialTimeSeriesState,
+      TimeSeriesActions.timeSeriesSucceeded({ symbol, range, series })
+    );
+    expect(state.series[symbol]?.[range]).toEqual(series);
+  });
+
+  it('stores error on failure', () => {
+    const error = serializeError(new Error('fail'), 'TEST');
+    const state = timeSeriesReducer(
+      initialTimeSeriesState,
+      TimeSeriesActions.timeSeriesFailed({ symbol, range, error })
+    );
+    expect(state.errors[symbol]?.[range]).toEqual(error);
+  });
+
+  it('evicts cached range', () => {
+    const withSeries = timeSeriesReducer(
+      initialTimeSeriesState,
+      TimeSeriesActions.timeSeriesSucceeded({ symbol, range, series })
+    );
+    const state = timeSeriesReducer(withSeries, TimeSeriesActions.timeSeriesEvictRange({ symbol, range }));
+    expect(state.series[symbol]).toBeUndefined();
+  });
+});

--- a/boersencockpit/src/app/features/timeseries/state/timeseries.reducer.ts
+++ b/boersencockpit/src/app/features/timeseries/state/timeseries.reducer.ts
@@ -1,0 +1,84 @@
+import { createReducer, on } from '@ngrx/store';
+
+import * as TimeSeriesActions from './timeseries.actions';
+import { TimeSeriesState } from './timeseries.models';
+
+export const initialTimeSeriesState: TimeSeriesState = {
+  series: {},
+  loading: {},
+  errors: {},
+};
+
+export const timeSeriesReducer = createReducer(
+  initialTimeSeriesState,
+  on(TimeSeriesActions.timeSeriesRequested, (state, { symbol, range }) => ({
+    series: state.series,
+    loading: setNestedFlag(state.loading, symbol, range, true),
+    errors: setNestedError(state.errors, symbol, range, null),
+  })),
+  on(TimeSeriesActions.timeSeriesSucceeded, (state, { symbol, range, series }) => ({
+    series: setNestedSeries(state.series, symbol, range, series),
+    loading: setNestedFlag(state.loading, symbol, range, false),
+    errors: setNestedError(state.errors, symbol, range, null),
+  })),
+  on(TimeSeriesActions.timeSeriesFailed, (state, { symbol, range, error }) => ({
+    series: state.series,
+    loading: setNestedFlag(state.loading, symbol, range, false),
+    errors: setNestedError(state.errors, symbol, range, error),
+  })),
+  on(TimeSeriesActions.timeSeriesEvictRange, (state, { symbol, range }) => ({
+    series: removeNestedEntry(state.series, symbol, range),
+    loading: removeNestedEntry(state.loading, symbol, range),
+    errors: removeNestedEntry(state.errors, symbol, range),
+  }))
+);
+
+const setNestedFlag = <T extends Record<string, Partial<Record<string, boolean>>>>(
+  state: T,
+  symbol: string,
+  range: string,
+  value: boolean
+): T => ({
+  ...state,
+  [symbol]: { ...(state[symbol] ?? {}), [range]: value },
+});
+
+const setNestedError = <T extends Record<string, Partial<Record<string, unknown>>>>(
+  state: T,
+  symbol: string,
+  range: string,
+  value: unknown
+): T => ({
+  ...state,
+  [symbol]: { ...(state[symbol] ?? {}), [range]: value },
+});
+
+const setNestedSeries = <T>(
+  state: Readonly<Record<string, Partial<Record<string, T>>>>,
+  symbol: string,
+  range: string,
+  value: T
+): Readonly<Record<string, Partial<Record<string, T>>>> => ({
+  ...state,
+  [symbol]: { ...(state[symbol] ?? {}), [range]: value },
+});
+
+const removeNestedEntry = <T extends Record<string, Partial<Record<string, unknown>>>>(
+  state: T,
+  symbol: string,
+  range: string
+): T => {
+  const nested = state[symbol];
+  if (!nested) {
+    return state;
+  }
+  const { [range]: _, ...rest } = nested;
+  if (Object.keys(rest).length === 0) {
+    const { [symbol]: __, ...remaining } = state;
+    return remaining as T;
+  }
+  return {
+    ...state,
+    [symbol]: rest,
+  } as T;
+};

--- a/boersencockpit/src/app/features/timeseries/state/timeseries.selectors.spec.ts
+++ b/boersencockpit/src/app/features/timeseries/state/timeseries.selectors.spec.ts
@@ -1,0 +1,39 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { TimeSeries } from '../../../domain/models/candle';
+import {
+  selectTimeSeries,
+  selectHasTimeSeries,
+  selectTimeSeriesLoading,
+} from './timeseries.selectors';
+import { initialTimeSeriesState } from './timeseries.reducer';
+
+const symbol = asSymbol('AAPL');
+const range = '1M' as const;
+const series: TimeSeries = {
+  symbol,
+  candles: [{ t: '2024-01-01T00:00:00.000Z', o: 1, h: 1, l: 1, c: 1 }],
+};
+
+describe('time series selectors', () => {
+  const state = {
+    ...initialTimeSeriesState,
+    series: { [symbol]: { [range]: series } },
+    loading: { [symbol]: { [range]: true } },
+  };
+  const rootState = { timeseries: state } as { timeseries: typeof state };
+
+  it('selectTimeSeries returns cached series', () => {
+    const selector = selectTimeSeries(symbol, range);
+    expect(selector(rootState)).toEqual(series);
+  });
+
+  it('selectHasTimeSeries returns true when present', () => {
+    const selector = selectHasTimeSeries(symbol, range);
+    expect(selector(rootState)).toBe(true);
+  });
+
+  it('selectTimeSeriesLoading reflects loading flag', () => {
+    const selector = selectTimeSeriesLoading(symbol, range);
+    expect(selector(rootState)).toBe(true);
+  });
+});

--- a/boersencockpit/src/app/features/timeseries/state/timeseries.selectors.ts
+++ b/boersencockpit/src/app/features/timeseries/state/timeseries.selectors.ts
@@ -1,0 +1,47 @@
+import { createFeature } from '@ngrx/store';
+import { createSelector } from '@ngrx/store';
+
+import { TIMESERIES_FEATURE_KEY, TimeSeriesState } from './timeseries.models';
+import { timeSeriesReducer } from './timeseries.reducer';
+import { RangeKey } from '../../../core/api/price-api.port';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+export const timeSeriesFeature = createFeature({
+  name: TIMESERIES_FEATURE_KEY,
+  reducer: timeSeriesReducer,
+});
+
+export const {
+  name: timeSeriesFeatureKey,
+  reducer: timeSeriesFeatureReducer,
+  selectTimeseriesState,
+} = timeSeriesFeature;
+
+export const selectTimeSeriesState = selectTimeseriesState;
+
+export const selectSeriesMap = createSelector(
+  selectTimeSeriesState,
+  (state): TimeSeriesState['series'] => state.series
+);
+
+export const selectLoadingMap = createSelector(
+  selectTimeSeriesState,
+  (state): TimeSeriesState['loading'] => state.loading
+);
+
+export const selectErrorsMap = createSelector(
+  selectTimeSeriesState,
+  (state): TimeSeriesState['errors'] => state.errors
+);
+
+export const selectTimeSeries = (symbol: Symbol, range: RangeKey) =>
+  createSelector(selectSeriesMap, (seriesMap) => seriesMap[symbol]?.[range] ?? null);
+
+export const selectHasTimeSeries = (symbol: Symbol, range: RangeKey) =>
+  createSelector(selectSeriesMap, (seriesMap) => Boolean(seriesMap[symbol]?.[range]));
+
+export const selectTimeSeriesLoading = (symbol: Symbol, range: RangeKey) =>
+  createSelector(selectLoadingMap, (loadingMap) => Boolean(loadingMap[symbol]?.[range]));
+
+export const selectTimeSeriesError = (symbol: Symbol, range: RangeKey) =>
+  createSelector(selectErrorsMap, (errorsMap) => errorsMap[symbol]?.[range] ?? null);

--- a/boersencockpit/src/app/features/trades/state/trades.actions.ts
+++ b/boersencockpit/src/app/features/trades/state/trades.actions.ts
@@ -1,0 +1,46 @@
+import { createAction, props } from '@ngrx/store';
+
+import { SerializableError } from '../../../core/errors/serializable-error';
+import { Trade } from '../../../domain/models/trade';
+
+export const addTradeRequested = createAction(
+  '[Trades] Add Trade Requested',
+  props<{ readonly tradeInput: unknown }>()
+);
+
+export const addTradeSucceeded = createAction(
+  '[Trades] Add Trade Succeeded',
+  props<{ readonly trade: Trade }>()
+);
+
+export const addTradeFailed = createAction(
+  '[Trades] Add Trade Failed',
+  props<{ readonly error: SerializableError }>()
+);
+
+export const removeTradeRequested = createAction(
+  '[Trades] Remove Trade Requested',
+  props<{ readonly id: string }>()
+);
+
+export const removeTradeSucceeded = createAction(
+  '[Trades] Remove Trade Succeeded',
+  props<{ readonly id: string }>()
+);
+
+export const removeTradeFailed = createAction(
+  '[Trades] Remove Trade Failed',
+  props<{ readonly id: string; readonly error: SerializableError }>()
+);
+
+export const loadTradesHydrateRequested = createAction('[Trades] Load Trades Hydrate Requested');
+
+export const loadTradesHydrateSucceeded = createAction(
+  '[Trades] Load Trades Hydrate Succeeded',
+  props<{ readonly trades: readonly Trade[] }>()
+);
+
+export const loadTradesHydrateFailed = createAction(
+  '[Trades] Load Trades Hydrate Failed',
+  props<{ readonly error: SerializableError }>()
+);

--- a/boersencockpit/src/app/features/trades/state/trades.effects.spec.ts
+++ b/boersencockpit/src/app/features/trades/state/trades.effects.spec.ts
@@ -1,0 +1,107 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { Observable } from 'rxjs';
+
+import { runMarbles } from '../../../testing/marble-helpers';
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import * as TradesActions from './trades.actions';
+import { TradesEffects } from './trades.effects';
+import { tradesAdapter, initialTradesState } from './trades.reducer';
+import { TradesState } from './trades.models';
+
+const baseTrade = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  symbol: asSymbol('AAPL'),
+  side: 'BUY' as const,
+  quantity: 5,
+  price: 100,
+  timestamp: '2024-01-01T00:00:00.000Z',
+};
+
+describe('TradesEffects', () => {
+  let actions$: Observable<unknown>;
+  let effects: TradesEffects;
+  let store: MockStore<{ trades: TradesState }>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TradesEffects,
+        provideMockActions(() => actions$),
+        provideMockStore({ initialState: { trades: initialTradesState } }),
+      ],
+    });
+    effects = TestBed.inject(TradesEffects);
+    store = TestBed.inject(MockStore);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('emits addTradeSucceeded when trade is valid', () => {
+    runMarbles(({ hot, expectObservable }) => {
+      actions$ = hot('-a', { a: TradesActions.addTradeRequested({ tradeInput: baseTrade }) });
+      const expected = '-b';
+      const expectedValues = {
+        b: TradesActions.addTradeSucceeded({ trade: baseTrade }),
+      };
+      expectObservable(effects.addTradeRequested$).toBe(expected, expectedValues);
+    });
+  });
+
+  it('emits addTradeFailed when trade is invalid', () => {
+    const invalidTrade = { ...baseTrade, quantity: 0 };
+    runMarbles(({ hot, expectObservable }) => {
+      actions$ = hot('-a', { a: TradesActions.addTradeRequested({ tradeInput: invalidTrade }) });
+      const expected = '-b';
+      expectObservable(effects.addTradeRequested$).toBe(expected, {
+        b: expect.objectContaining({
+          type: TradesActions.addTradeFailed.type,
+          error: expect.objectContaining({ code: 'VAL/TRADE' }),
+        }) as unknown,
+      });
+    });
+  });
+
+  it('emits removeTradeSucceeded when trade exists', () => {
+    const stateWithTrade = tradesAdapter.addOne(baseTrade, initialTradesState);
+    store.setState({ trades: stateWithTrade });
+
+    runMarbles(({ hot, expectObservable }) => {
+      actions$ = hot('-a', { a: TradesActions.removeTradeRequested({ id: baseTrade.id }) });
+      const expected = '-b';
+      const expectedValues = {
+        b: TradesActions.removeTradeSucceeded({ id: baseTrade.id }),
+      };
+      expectObservable(effects.removeTradeRequested$).toBe(expected, expectedValues);
+    });
+  });
+
+  it('emits removeTradeFailed when trade does not exist', () => {
+    store.setState({ trades: initialTradesState });
+
+    runMarbles(({ hot, expectObservable }) => {
+      actions$ = hot('-a', { a: TradesActions.removeTradeRequested({ id: 'missing' }) });
+      const expected = '-b';
+      expectObservable(effects.removeTradeRequested$).toBe(expected, {
+        b: expect.objectContaining({
+          type: TradesActions.removeTradeFailed.type,
+          error: expect.objectContaining({ code: 'VAL/TRADE_NOT_FOUND' }),
+        }) as unknown,
+      });
+    });
+  });
+
+  it('hydrates with empty array on load request', () => {
+    runMarbles(({ hot, expectObservable }) => {
+      actions$ = hot('-a', { a: TradesActions.loadTradesHydrateRequested() });
+      const expected = '-b';
+      const expectedValues = {
+        b: TradesActions.loadTradesHydrateSucceeded({ trades: [] }),
+      };
+      expectObservable(effects.loadTradesHydrateRequested$).toBe(expected, expectedValues);
+    });
+  });
+});

--- a/boersencockpit/src/app/features/trades/state/trades.effects.ts
+++ b/boersencockpit/src/app/features/trades/state/trades.effects.ts
@@ -1,0 +1,55 @@
+import { inject, Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { map, withLatestFrom } from 'rxjs/operators';
+
+import { serializeError } from '../../../core/errors/serializable-error';
+import { AppError } from '../../../core/errors/app-error';
+import { parseTrade } from '../../../domain/schemas/trade.schema';
+import * as TradesActions from './trades.actions';
+import { selectTradesEntities } from './trades.selectors';
+
+@Injectable()
+export class TradesEffects {
+  private readonly actions$ = inject(Actions);
+  private readonly store = inject(Store);
+
+  readonly addTradeRequested$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TradesActions.addTradeRequested),
+      map(({ tradeInput }) => {
+        try {
+          const trade = parseTrade(tradeInput);
+          return TradesActions.addTradeSucceeded({ trade });
+        } catch (error) {
+          return TradesActions.addTradeFailed({
+            error: serializeError(error, 'VAL/TRADE'),
+          });
+        }
+      })
+    )
+  );
+
+  readonly removeTradeRequested$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TradesActions.removeTradeRequested),
+      withLatestFrom(this.store.select(selectTradesEntities)),
+      map(([{ id }, entities]) => {
+        if (entities[id]) {
+          return TradesActions.removeTradeSucceeded({ id });
+        }
+        return TradesActions.removeTradeFailed({
+          id,
+          error: serializeError(new AppError(`Trade ${id} not found.`, 'VAL/TRADE_NOT_FOUND')),
+        });
+      })
+    )
+  );
+
+  readonly loadTradesHydrateRequested$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TradesActions.loadTradesHydrateRequested),
+      map(() => TradesActions.loadTradesHydrateSucceeded({ trades: [] }))
+    )
+  );
+}

--- a/boersencockpit/src/app/features/trades/state/trades.models.ts
+++ b/boersencockpit/src/app/features/trades/state/trades.models.ts
@@ -1,0 +1,11 @@
+import { EntityState } from '@ngrx/entity';
+
+import { SerializableError } from '../../../core/errors/serializable-error';
+import { Trade } from '../../../domain/models/trade';
+
+export interface TradesState extends EntityState<Trade> {
+  readonly loading: boolean;
+  readonly error: SerializableError | null;
+}
+
+export const TRADES_FEATURE_KEY = 'trades';

--- a/boersencockpit/src/app/features/trades/state/trades.reducer.spec.ts
+++ b/boersencockpit/src/app/features/trades/state/trades.reducer.spec.ts
@@ -1,0 +1,44 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { Trade } from '../../../domain/models/trade';
+import { serializeError } from '../../../core/errors/serializable-error';
+import * as TradesActions from './trades.actions';
+import { initialTradesState, tradesReducer } from './trades.reducer';
+
+const baseTrade: Trade = {
+  id: 'trade-1',
+  symbol: asSymbol('AAPL'),
+  side: 'BUY',
+  quantity: 10,
+  price: 100,
+  timestamp: '2024-01-01T00:00:00.000Z',
+};
+
+describe('tradesReducer', () => {
+  it('returns initial state for unknown action', () => {
+    const state = tradesReducer(undefined, { type: 'Unknown' });
+    expect(state).toEqual(initialTradesState);
+  });
+
+  it('sets loading on addTradeRequested', () => {
+    const state = tradesReducer(initialTradesState, TradesActions.addTradeRequested({ tradeInput: baseTrade }));
+    expect(state.loading).toBe(true);
+  });
+
+  it('adds trade on addTradeSucceeded', () => {
+    const state = tradesReducer(initialTradesState, TradesActions.addTradeSucceeded({ trade: baseTrade }));
+    expect(state.entities[baseTrade.id]).toEqual(baseTrade);
+    expect(state.loading).toBe(false);
+  });
+
+  it('removes trade on removeTradeSucceeded', () => {
+    const withTrade = tradesReducer(initialTradesState, TradesActions.addTradeSucceeded({ trade: baseTrade }));
+    const state = tradesReducer(withTrade, TradesActions.removeTradeSucceeded({ id: baseTrade.id }));
+    expect(state.entities[baseTrade.id]).toBeUndefined();
+  });
+
+  it('stores error on failure', () => {
+    const error = serializeError(new Error('nope'), 'TEST/ERR');
+    const state = tradesReducer(initialTradesState, TradesActions.addTradeFailed({ error }));
+    expect(state.error).toEqual(error);
+  });
+});

--- a/boersencockpit/src/app/features/trades/state/trades.reducer.ts
+++ b/boersencockpit/src/app/features/trades/state/trades.reducer.ts
@@ -1,0 +1,66 @@
+import { createEntityAdapter } from '@ngrx/entity';
+import { createReducer, on } from '@ngrx/store';
+
+import { TradesState } from './trades.models';
+import * as TradesActions from './trades.actions';
+import { Trade } from '../../../domain/models/trade';
+
+export const tradesAdapter = createEntityAdapter<Trade>({
+  selectId: (trade) => trade.id,
+  sortComparer: (a, b) => a.timestamp.localeCompare(b.timestamp),
+});
+
+export const initialTradesState: TradesState = tradesAdapter.getInitialState({
+  loading: false,
+  error: null,
+});
+
+export const tradesReducer = createReducer(
+  initialTradesState,
+  on(TradesActions.loadTradesHydrateRequested, (state) => ({
+    ...state,
+    loading: true,
+    error: null,
+  })),
+  on(TradesActions.loadTradesHydrateSucceeded, (state, { trades }) =>
+    tradesAdapter.setAll([...trades], {
+      ...state,
+      loading: false,
+    })
+  ),
+  on(TradesActions.loadTradesHydrateFailed, (state, { error }) => ({
+    ...state,
+    loading: false,
+    error,
+  })),
+  on(TradesActions.addTradeRequested, (state) => ({
+    ...state,
+    loading: true,
+  })),
+  on(TradesActions.addTradeSucceeded, (state, { trade }) =>
+    tradesAdapter.addOne(trade, {
+      ...state,
+      loading: false,
+    })
+  ),
+  on(TradesActions.addTradeFailed, (state, { error }) => ({
+    ...state,
+    loading: false,
+    error,
+  })),
+  on(TradesActions.removeTradeRequested, (state) => ({
+    ...state,
+    loading: true,
+  })),
+  on(TradesActions.removeTradeSucceeded, (state, { id }) =>
+    tradesAdapter.removeOne(id, {
+      ...state,
+      loading: false,
+    })
+  ),
+  on(TradesActions.removeTradeFailed, (state, { error }) => ({
+    ...state,
+    loading: false,
+    error,
+  }))
+);

--- a/boersencockpit/src/app/features/trades/state/trades.selectors.spec.ts
+++ b/boersencockpit/src/app/features/trades/state/trades.selectors.spec.ts
@@ -1,0 +1,56 @@
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { Trade } from '../../../domain/models/trade';
+import { tradesAdapter, initialTradesState } from './trades.reducer';
+import { selectAllTrades, selectTradeCount, selectTradesBySymbol, selectPositions } from './trades.selectors';
+
+const trades: Trade[] = [
+  {
+    id: 't1',
+    symbol: asSymbol('SAP'),
+    side: 'BUY',
+    quantity: 10,
+    price: 100,
+    timestamp: '2024-01-01T00:00:00.000Z',
+  },
+  {
+    id: 't2',
+    symbol: asSymbol('SAP'),
+    side: 'SELL',
+    quantity: 4,
+    price: 120,
+    timestamp: '2024-01-02T00:00:00.000Z',
+  },
+  {
+    id: 't3',
+    symbol: asSymbol('AAPL'),
+    side: 'BUY',
+    quantity: 5,
+    price: 80,
+    timestamp: '2024-01-03T00:00:00.000Z',
+  },
+];
+
+describe('trades selectors', () => {
+  const state = tradesAdapter.setAll(trades, initialTradesState);
+  const rootState = { trades: state } as { trades: typeof state };
+
+  it('selectAllTrades returns all trades', () => {
+    expect(selectAllTrades.projector(state)).toHaveLength(trades.length);
+  });
+
+  it('selectTradeCount returns total count', () => {
+    expect(selectTradeCount.projector(state)).toBe(trades.length);
+  });
+
+  it('selectTradesBySymbol filters trades', () => {
+    const selector = selectTradesBySymbol(asSymbol('SAP'));
+    expect(selector(rootState)).toHaveLength(2);
+  });
+
+  it('selectPositions computes FIFO positions', () => {
+    const [firstPosition, secondPosition] = selectPositions.projector(trades);
+    expect(firstPosition.symbol).toEqual(asSymbol('AAPL'));
+    expect(secondPosition.totalQuantity).toBe(6);
+    expect(secondPosition.realizedPnL).toBeCloseTo(80);
+  });
+});

--- a/boersencockpit/src/app/features/trades/state/trades.selectors.ts
+++ b/boersencockpit/src/app/features/trades/state/trades.selectors.ts
@@ -1,0 +1,33 @@
+import { createFeature } from '@ngrx/store';
+import { createSelector } from '@ngrx/store';
+
+import { TRADES_FEATURE_KEY } from './trades.models';
+import { tradesAdapter, tradesReducer } from './trades.reducer';
+import { Symbol } from '../../../domain/models/symbol.brand';
+import { computePositions } from '../../../domain/utils/portfolio';
+
+const { selectAll, selectEntities, selectTotal } = tradesAdapter.getSelectors();
+
+export const tradesFeature = createFeature({
+  name: TRADES_FEATURE_KEY,
+  reducer: tradesReducer,
+  extraSelectors: ({ selectTradesState }) => ({
+    selectAllTrades: createSelector(selectTradesState, selectAll),
+    selectTradesEntities: createSelector(selectTradesState, selectEntities),
+    selectTradeCount: createSelector(selectTradesState, selectTotal),
+  }),
+});
+
+export const {
+  name: tradesFeatureKey,
+  reducer: tradesFeatureReducer,
+  selectTradesState,
+  selectAllTrades,
+  selectTradesEntities,
+  selectTradeCount,
+} = tradesFeature;
+
+export const selectTradesBySymbol = (symbol: Symbol) =>
+  createSelector(selectAllTrades, (trades) => trades.filter((trade) => trade.symbol === symbol));
+
+export const selectPositions = createSelector(selectAllTrades, (trades) => computePositions(trades));

--- a/boersencockpit/src/app/store/app.state.ts
+++ b/boersencockpit/src/app/store/app.state.ts
@@ -1,0 +1,28 @@
+import { ActionReducerMap } from '@ngrx/store';
+
+import { StocksState } from '../features/stocks/state/stocks.models';
+import { stocksFeatureReducer } from '../features/stocks/state/stocks.selectors';
+import { TradesState } from '../features/trades/state/trades.models';
+import { tradesFeatureReducer } from '../features/trades/state/trades.selectors';
+import { QuotesState } from '../features/quotes/state/quotes.models';
+import { quotesFeatureReducer } from '../features/quotes/state/quotes.selectors';
+import { TimeSeriesState } from '../features/timeseries/state/timeseries.models';
+import { timeSeriesFeatureReducer } from '../features/timeseries/state/timeseries.selectors';
+import { PortfolioState } from '../features/portfolio/state/portfolio.models';
+import { portfolioFeatureReducer } from '../features/portfolio/state/portfolio.selectors';
+
+export interface AppState {
+  readonly stocks: StocksState;
+  readonly trades: TradesState;
+  readonly quotes: QuotesState;
+  readonly timeseries: TimeSeriesState;
+  readonly portfolio: PortfolioState;
+}
+
+export const appReducers: ActionReducerMap<AppState> = {
+  stocks: stocksFeatureReducer,
+  trades: tradesFeatureReducer,
+  quotes: quotesFeatureReducer,
+  timeseries: timeSeriesFeatureReducer,
+  portfolio: portfolioFeatureReducer,
+};

--- a/boersencockpit/src/app/store/app.store.module.spec.ts
+++ b/boersencockpit/src/app/store/app.store.module.spec.ts
@@ -1,0 +1,12 @@
+import { provideAppStore } from './app.store.module';
+import { environment } from '../../environments/environment';
+
+describe('provideAppStore', () => {
+  it('creates providers with devtools in development', () => {
+    const providers = provideAppStore();
+    expect(providers).toBeDefined();
+    if (!environment.production) {
+      expect(JSON.stringify(providers)).toContain('store-devtools');
+    }
+  });
+});

--- a/boersencockpit/src/app/store/app.store.module.ts
+++ b/boersencockpit/src/app/store/app.store.module.ts
@@ -1,0 +1,30 @@
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+import { provideEffects } from '@ngrx/effects';
+import { provideRouterStore } from '@ngrx/router-store';
+import { provideStore } from '@ngrx/store';
+import { provideStoreDevtools } from '@ngrx/store-devtools';
+
+import { environment } from '../../environments/environment';
+import { StocksEffects } from '../features/stocks/state/stocks.effects';
+import { TradesEffects } from '../features/trades/state/trades.effects';
+import { QuotesEffects } from '../features/quotes/state/quotes.effects';
+import { TimeSeriesEffects } from '../features/timeseries/state/timeseries.effects';
+import { PortfolioEffects } from '../features/portfolio/state/portfolio.effects';
+import { appReducers } from './app.state';
+
+export const provideAppStore = (): EnvironmentProviders =>
+  makeEnvironmentProviders([
+    provideStore(appReducers, {
+      runtimeChecks: {
+        strictStateImmutability: true,
+        strictActionImmutability: true,
+        strictStateSerializability: true,
+        strictActionSerializability: true,
+      },
+    }),
+    provideEffects([StocksEffects, TradesEffects, QuotesEffects, TimeSeriesEffects, PortfolioEffects]),
+    provideRouterStore(),
+    ...(environment.production
+      ? []
+      : [provideStoreDevtools({ maxAge: 25, logOnly: environment.production })]),
+  ]);

--- a/boersencockpit/src/app/testing/marble-helpers.ts
+++ b/boersencockpit/src/app/testing/marble-helpers.ts
@@ -1,0 +1,13 @@
+import { RunHelpers, TestScheduler } from 'rxjs/testing';
+
+export type MarbleAssert = (helpers: RunHelpers) => void;
+
+export const createTestScheduler = (): TestScheduler =>
+  new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });
+
+export const runMarbles = (assertFn: MarbleAssert): void => {
+  const scheduler = createTestScheduler();
+  scheduler.run(assertFn);
+};

--- a/boersencockpit/src/environments/environment.production.ts
+++ b/boersencockpit/src/environments/environment.production.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true,
+};

--- a/boersencockpit/src/environments/environment.ts
+++ b/boersencockpit/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false,
+};


### PR DESCRIPTION
## Summary
- provide NgRx store providers with runtime checks, devtools, and router integration
- implement stocks, trades, quotes, timeseries, and portfolio slices with actions, reducers, selectors, and effects
- add serialization utilities, API token, and jest marble helpers with comprehensive unit/effect tests

## Testing
- npm run test:cov

------
https://chatgpt.com/codex/tasks/task_e_68d67d4dd2c88321a29385cdecc0dc5d