### PR TITLE
Implement stocks UI pages and chart integration

### DIFF
--- a/boersencockpit/cypress/e2e/stocks-flow.cy.ts
+++ b/boersencockpit/cypress/e2e/stocks-flow.cy.ts
@@ -1,0 +1,33 @@
+describe('Stocks feature flow', () => {
+  beforeEach(() => {
+    cy.visit('/stocks');
+  });
+
+  it('allows adding a trade and viewing details', () => {
+    cy.get('[data-testid="quote"]').should('exist');
+
+    cy.contains('Aktie hinzufügen').click();
+    cy.url().should('include', '/stocks/add');
+
+    cy.get('#trade-symbol').clear().type('SAP');
+    cy.get('#trade-side').select('Kauf');
+    cy.get('#trade-quantity').clear().type('5');
+    cy.get('#trade-price').clear().type('120');
+    cy.get('#trade-timestamp').clear().type('2024-01-01T10:00');
+    cy.get('#trade-note').type('Testkauf');
+    cy.contains('Speichern').click();
+
+    cy.url().should('include', '/stocks/SAP');
+
+    cy.contains('Trade hinzufügen');
+    cy.get('app-timeseries-chart').should('exist');
+    cy.contains('Trades');
+
+    cy.contains('1W').focus().type('{enter}');
+    cy.contains('1M').focus();
+
+    cy.contains('Löschen').first().click({ force: true });
+    cy.contains('Trade löschen?');
+    cy.contains('Löschen').last().click();
+  });
+});

--- a/boersencockpit/package-lock.json
+++ b/boersencockpit/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^17.3.0",
+        "@angular/cdk": "^17.3.10",
         "@angular/common": "^17.3.0",
         "@angular/compiler": "^17.3.0",
         "@angular/core": "^17.3.0",
@@ -21,6 +22,9 @@
         "@ngrx/router-store": "^17.2.0",
         "@ngrx/store": "^17.2.0",
         "@ngrx/store-devtools": "^17.2.0",
+        "chart.js": "^4.5.0",
+        "chartjs-plugin-annotation": "^3.1.0",
+        "ng2-charts": "^6.0.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zod": "^3.23.8",
@@ -532,6 +536,23 @@
       },
       "peerDependencies": {
         "@angular/core": "17.3.12"
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "17.3.10",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.10.tgz",
+      "integrity": "sha512-b1qktT2c1TTTe5nTji/kFAVW92fULK0YhYAvJ+BjZTPKu2FniZNe8o4qqQ0pUuvtMu+ZQxp/QqFYoidIVCjScg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^17.0.0 || ^18.0.0",
+        "@angular/core": "^17.0.0 || ^18.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -3935,6 +3956,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -7284,6 +7311,27 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-annotation": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.1.0.tgz",
+      "integrity": "sha512-EkAed6/ycXD/7n0ShrlT1T2Hm3acnbFhgkIEJLa0X+M6S16x0zwj1Fv4suv/2bwayCT3jGPdAtI9uLcAMToaQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=4.0.0"
+      }
     },
     "node_modules/check-more-types": {
       "version": "2.24.0",
@@ -13160,6 +13208,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -13895,6 +13949,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ng2-charts": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-6.0.1.tgz",
+      "integrity": "sha512-pO7evbvHqjiKB7zqE12tCKWQI9gmQ8DVOEaWBBLlxJabc4fLGk7o9t4jC4+Q9pJiQrTtQkugm0dIPQ4PFHUaWA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.15",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": ">=17.0.0",
+        "@angular/common": ">=17.0.0",
+        "@angular/core": ">=17.0.0",
+        "@angular/platform-browser": ">=17.0.0",
+        "chart.js": "^3.4.0 || ^4.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/nice-napi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
@@ -14597,7 +14669,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -14638,7 +14710,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"

--- a/boersencockpit/package.json
+++ b/boersencockpit/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@angular/animations": "^17.3.0",
+    "@angular/cdk": "^17.3.10",
     "@angular/common": "^17.3.0",
     "@angular/compiler": "^17.3.0",
     "@angular/core": "^17.3.0",
@@ -32,6 +33,9 @@
     "@ngrx/router-store": "^17.2.0",
     "@ngrx/store": "^17.2.0",
     "@ngrx/store-devtools": "^17.2.0",
+    "chart.js": "^4.5.0",
+    "chartjs-plugin-annotation": "^3.1.0",
+    "ng2-charts": "^6.0.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zod": "^3.23.8",

--- a/boersencockpit/src/app/features/stocks/components/chart.registry.ts
+++ b/boersencockpit/src/app/features/stocks/components/chart.registry.ts
@@ -1,0 +1,4 @@
+import { Chart, registerables } from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+
+Chart.register(...registerables, annotationPlugin);

--- a/boersencockpit/src/app/features/stocks/components/stock-list-item.css
+++ b/boersencockpit/src/app/features/stocks/components/stock-list-item.css
@@ -1,4 +1,3 @@
 :host {
   display: block;
-  position: relative;
 }

--- a/boersencockpit/src/app/features/stocks/components/stock-list-item.html
+++ b/boersencockpit/src/app/features/stocks/components/stock-list-item.html
@@ -1,0 +1,35 @@
+<a
+  class="group flex flex-col gap-4 rounded-xl border border-neutral-200 bg-white p-4 shadow-sm transition hover:border-neutral-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900"
+  [routerLink]="['/stocks', symbol]"
+  role="link"
+  [attr.aria-label]="'Zu Detailansicht von ' + symbol"
+>
+  <div class="flex items-center justify-between gap-4">
+    <div class="space-y-1">
+      <p class="font-mono text-lg font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
+        {{ symbol }}
+      </p>
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">{{ name }}</p>
+    </div>
+    <span class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium" [ngClass]="changeBadgeClasses">
+      <ng-container *ngIf="quote; else neutralChange">
+        {{ changePrefix }}{{ (quote.changePct / 100) | percent:'1.2-2':'de-DE' }}
+      </ng-container>
+      <ng-template #neutralChange>–</ng-template>
+    </span>
+  </div>
+  <div class="flex items-baseline justify-between gap-4">
+    <div class="space-y-1">
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">Letzter Preis</p>
+      <p class="text-xl font-semibold text-neutral-900 dark:text-neutral-100" data-testid="quote">
+        <ng-container *ngIf="quote; else priceSkeleton">
+          {{ quote.price | currency: currency:'symbol':'1.2-2':'de-DE' }}
+        </ng-container>
+      </p>
+      <ng-template #priceSkeleton>
+        <span class="inline-flex h-6 w-24 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700" aria-hidden="true"></span>
+      </ng-template>
+    </div>
+    <span class="text-xs uppercase tracking-wide text-neutral-400">Details →</span>
+  </div>
+</a>

--- a/boersencockpit/src/app/features/stocks/components/stock-list-item.ts
+++ b/boersencockpit/src/app/features/stocks/components/stock-list-item.ts
@@ -1,0 +1,37 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { PriceQuote } from '../../../domain/models/quote';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+@Component({
+  selector: 'app-stock-list-item',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './stock-list-item.html',
+  styleUrl: './stock-list-item.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StockListItemComponent {
+  @Input({ required: true }) symbol!: Symbol;
+  @Input({ required: true }) name!: string;
+  @Input({ required: true }) currency!: 'EUR' | 'USD' | 'CHF' | 'GBP';
+  @Input() quote: PriceQuote | null = null;
+
+  protected get changeBadgeClasses(): string {
+    if (!this.quote) {
+      return 'bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300';
+    }
+    return this.quote.changePct >= 0
+      ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300'
+      : 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300';
+  }
+
+  protected get changePrefix(): string {
+    if (!this.quote) {
+      return '';
+    }
+    return this.quote.changePct >= 0 ? '+' : '';
+  }
+}

--- a/boersencockpit/src/app/features/stocks/components/timeseries-chart.css
+++ b/boersencockpit/src/app/features/stocks/components/timeseries-chart.css
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+}
+
+.chart-container {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+
+@media (max-width: 768px) {
+  .chart-container {
+    aspect-ratio: 4 / 3;
+  }
+}

--- a/boersencockpit/src/app/features/stocks/components/timeseries-chart.html
+++ b/boersencockpit/src/app/features/stocks/components/timeseries-chart.html
@@ -1,0 +1,59 @@
+<section class="space-y-4">
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h2 class="text-lg font-semibold text-neutral-900 dark:text-neutral-100">Preisverlauf</h2>
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">Vergangene Schlusskurse mit Kauf- und Verkaufsmarkern.</p>
+    </div>
+    <div class="flex flex-wrap items-center gap-2" role="group" aria-label="Zeithorizont wählen">
+      <button
+        *ngFor="let rangeKey of ranges"
+        type="button"
+        class="rounded-full border px-3 py-1 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+        [ngClass]="{
+          'border-primary-500 bg-primary-600 text-white': rangeKey === range,
+          'border-neutral-300 bg-white text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800': rangeKey !== range
+        }"
+        [attr.aria-pressed]="rangeKey === range"
+        (click)="onRangeChange(rangeKey)"
+      >
+        {{ rangeKey }}
+      </button>
+    </div>
+  </header>
+
+  <div
+    *ngIf="error && !loading; else chartContent"
+    class="flex flex-col items-center justify-center gap-3 rounded-xl border border-rose-300 bg-rose-50 p-6 text-center text-sm text-rose-700 dark:border-rose-700 dark:bg-rose-900/40 dark:text-rose-200"
+    role="alert"
+  >
+    <p>{{ error }}</p>
+    <button
+      type="button"
+      class="rounded-lg bg-rose-600 px-3 py-2 text-xs font-semibold text-white shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400"
+      (click)="onRetry()"
+    >
+      Erneut versuchen
+    </button>
+  </div>
+
+  <ng-template #chartContent>
+    <div
+      class="relative overflow-hidden rounded-2xl border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-900"
+      [attr.aria-busy]="loading"
+    >
+      <ng-container *ngIf="loading">
+        <div class="absolute inset-0 flex items-center justify-center bg-white/80 dark:bg-neutral-900/80">
+          <div class="h-10 w-10 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
+        </div>
+      </ng-container>
+      <figure class="space-y-2">
+        <div class="chart-container">
+          <canvas baseChart [type]="'line'" [data]="chartData" [options]="chartOptions"></canvas>
+        </div>
+        <figcaption class="text-xs text-neutral-500 dark:text-neutral-400">
+          Visualisiert Schlusskurse sowie Kauf/Verkauf-Anmerkungen basierend auf deinen erfassten Trades.
+        </figcaption>
+      </figure>
+    </div>
+  </ng-template>
+</section>

--- a/boersencockpit/src/app/features/stocks/components/timeseries-chart.spec.ts
+++ b/boersencockpit/src/app/features/stocks/components/timeseries-chart.spec.ts
@@ -1,0 +1,101 @@
+import { SimpleChange } from '@angular/core';
+
+jest.mock('ng2-charts', () => ({
+  BaseChartDirective: class {},
+}));
+
+import { TimeseriesChartComponent } from './timeseries-chart';
+import { TimeSeries } from '../../../domain/models/candle';
+import { Trade } from '../../../domain/models/trade';
+import { asSymbol } from '../../../domain/models/symbol.brand';
+
+const seriesFixture: TimeSeries = {
+  symbol: asSymbol('SAP'),
+  candles: [
+    { t: '2024-01-03T00:00:00.000Z', o: 120, h: 121, l: 119, c: 121 },
+    { t: '2024-01-01T00:00:00.000Z', o: 110, h: 112, l: 108, c: 110 },
+    { t: '2024-01-02T00:00:00.000Z', o: 115, h: 118, l: 114, c: 117 },
+  ],
+};
+
+const tradesFixture: Trade[] = [
+  {
+    id: '1',
+    symbol: asSymbol('SAP'),
+    side: 'BUY',
+    quantity: 5,
+    price: 111,
+    timestamp: '2024-01-01T00:00:00.000Z',
+  },
+  {
+    id: '2',
+    symbol: asSymbol('SAP'),
+    side: 'SELL',
+    quantity: 3,
+    price: 120,
+    timestamp: '2024-01-03T00:00:00.000Z',
+  },
+];
+
+describe('TimeseriesChartComponent', () => {
+let component: TimeseriesChartComponent;
+const originalNumberFormat = Intl.NumberFormat;
+
+beforeAll(() => {
+  (Intl as any).NumberFormat = jest.fn().mockImplementation(() => ({
+    format: (value: number) => `${value.toFixed(2).replace('.', ',')} €`,
+  }));
+});
+
+afterAll(() => {
+  (Intl as any).NumberFormat = originalNumberFormat;
+});
+
+beforeEach(() => {
+  component = new TimeseriesChartComponent();
+    component.currency = 'EUR';
+    component.range = '1M';
+    component.series = seriesFixture;
+    component.trades = tradesFixture;
+    component.ngOnChanges({
+      series: new SimpleChange(null, component.series, true),
+      trades: new SimpleChange(null, component.trades, true),
+      currency: new SimpleChange(null, component.currency, true),
+    });
+  });
+
+  it('maps candles to sorted chart data', () => {
+    const data = (component as any).chartData.datasets[0].data as { x: number; y: number }[];
+    expect(data.map((point) => point.y)).toEqual([110, 117, 121]);
+    expect(data.map((point) => point.x)).toEqual([
+      new Date('2024-01-01T00:00:00.000Z').getTime(),
+      new Date('2024-01-02T00:00:00.000Z').getTime(),
+      new Date('2024-01-03T00:00:00.000Z').getTime(),
+    ]);
+  });
+
+  it('creates annotations for each trade with correct coloring', () => {
+    const options = (component as any).chartOptions.plugins?.annotation as { annotations: Record<string, unknown> } | undefined;
+    expect(options).toBeDefined();
+    const annotations = options?.annotations ?? {};
+    expect(Object.keys(annotations)).toHaveLength(tradesFixture.length);
+    const values = Object.values(annotations) as { backgroundColor: string; rotation: number }[];
+    expect(values[0].backgroundColor).toBe('#16a34a');
+    expect(values[0].rotation).toBe(0);
+    expect(values[1].backgroundColor).toBe('#dc2626');
+    expect(values[1].rotation).toBe(180);
+  });
+
+  it('formats tooltip text for trades', () => {
+    const callbacks = (component as any).chartOptions.plugins?.tooltip?.callbacks;
+    expect(callbacks).toBeDefined();
+    const afterBody = callbacks.afterBody?.bind({});
+    const tooltip = afterBody?.([
+      {
+        parsed: { x: new Date('2024-01-03T00:00:00.000Z').getTime(), y: 121 },
+      } as any,
+    ]);
+    expect(tooltip?.[0]).toContain('Verkauf');
+    expect(tooltip?.[0]).toContain('120,00 €');
+  });
+});

--- a/boersencockpit/src/app/features/stocks/components/timeseries-chart.ts
+++ b/boersencockpit/src/app/features/stocks/components/timeseries-chart.ts
@@ -1,0 +1,194 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { BaseChartDirective } from 'ng2-charts';
+import { ChartConfiguration, ChartDataset, ChartOptions } from 'chart.js';
+import { AnnotationOptions } from 'chartjs-plugin-annotation';
+
+import './chart.registry';
+
+import { RangeKey } from '../../../core/api/price-api.port';
+import { Trade } from '../../../domain/models/trade';
+import { TimeSeries } from '../../../domain/models/candle';
+
+const RANGE_KEYS: readonly RangeKey[] = ['1W', '1M', '3M', '6M', '1Y', 'YTD', 'MAX'];
+
+const currencyFormatter = (currency: 'EUR' | 'USD' | 'CHF' | 'GBP') =>
+  new Intl.NumberFormat('de-DE', { style: 'currency', currency, maximumFractionDigits: 2 });
+
+const dateFormatter = new Intl.DateTimeFormat('de-DE', { dateStyle: 'short' });
+
+const tooltipDateFormatter = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+@Component({
+  selector: 'app-timeseries-chart',
+  standalone: true,
+  imports: [CommonModule, BaseChartDirective],
+  templateUrl: './timeseries-chart.html',
+  styleUrl: './timeseries-chart.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TimeseriesChartComponent implements OnChanges {
+  readonly ranges = RANGE_KEYS;
+
+  @Input() series: TimeSeries | null = null;
+  @Input() trades: readonly Trade[] | null = null;
+  @Input({ required: true }) range!: RangeKey;
+  @Input({ required: true }) currency: 'EUR' | 'USD' | 'CHF' | 'GBP' = 'EUR';
+  @Input() loading = false;
+  @Input() error: string | null = null;
+
+  @Output() readonly rangeChange = new EventEmitter<RangeKey>();
+  @Output() readonly retryRequested = new EventEmitter<void>();
+
+  protected chartData: ChartConfiguration<'line'>['data'] = { datasets: [] };
+  protected chartOptions: ChartOptions<'line'> = this.createChartOptions();
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['series'] || changes['trades'] || changes['currency']) {
+      this.chartData = this.createChartData();
+      this.chartOptions = this.createChartOptions();
+    }
+  }
+
+  protected onRangeChange(range: RangeKey): void {
+    if (range !== this.range) {
+      this.rangeChange.emit(range);
+    }
+  }
+
+  protected onRetry(): void {
+    this.retryRequested.emit();
+  }
+
+  private createChartData(): ChartConfiguration<'line'>['data'] {
+    const dataset: ChartDataset<'line'> = {
+      label: 'Schlusskurs',
+      data: (this.series?.candles ?? [])
+        .slice()
+        .sort((a, b) => new Date(a.t).getTime() - new Date(b.t).getTime())
+        .map((candle) => ({ x: new Date(candle.t).getTime(), y: candle.c })),
+      parsing: false,
+      normalized: true,
+      spanGaps: true,
+      borderColor: '#2563eb',
+      backgroundColor: 'rgba(37, 99, 235, 0.25)',
+      borderWidth: 2,
+      fill: {
+        target: 'origin',
+        above: 'rgba(37, 99, 235, 0.15)',
+      },
+      tension: 0.2,
+      pointRadius: 0,
+      pointHitRadius: 12,
+    };
+
+    return { datasets: [dataset] };
+  }
+
+  private createAnnotations(): Record<string, AnnotationOptions> {
+    const annotations: Record<string, AnnotationOptions> = {};
+    const trades = [...(this.trades ?? [])].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+    trades.forEach((trade, index) => {
+      const timestamp = new Date(trade.timestamp).getTime();
+      const annotationId = `${trade.id}-${index}`;
+      annotations[annotationId] = {
+        type: 'point',
+        xValue: timestamp,
+        yValue: trade.price,
+        radius: 6,
+        backgroundColor: trade.side === 'BUY' ? '#16a34a' : '#dc2626',
+        borderColor: trade.side === 'BUY' ? '#15803d' : '#b91c1c',
+        borderWidth: 2,
+        pointStyle: 'triangle',
+        rotation: trade.side === 'BUY' ? 0 : 180,
+      } satisfies AnnotationOptions;
+    });
+
+    return annotations;
+  }
+
+  private createChartOptions(): ChartOptions<'line'> {
+    const currencyFormat = currencyFormatter(this.currency);
+    const annotations = this.createAnnotations();
+
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        mode: 'nearest',
+        intersect: false,
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label: (context) => {
+              const price = currencyFormat.format(Number(context.parsed.y));
+              return `Preis: ${price}`;
+            },
+            afterBody: (items) => {
+              const tradeTooltip = this.buildTradeTooltip(items[0]?.parsed.x ?? null);
+              return tradeTooltip ? [tradeTooltip] : [];
+            },
+            title: (items) => {
+              const x = items[0]?.parsed.x;
+              if (typeof x === 'number') {
+                return tooltipDateFormatter.format(new Date(x));
+              }
+              return '';
+            },
+          },
+        },
+        annotation: {
+          annotations,
+        },
+      },
+      scales: {
+        x: {
+          type: 'linear',
+          ticks: {
+            callback: (value) => {
+              if (typeof value === 'number') {
+                return dateFormatter.format(new Date(value));
+              }
+              return '';
+            },
+            maxRotation: 0,
+            autoSkip: true,
+          },
+          grid: {
+            display: false,
+          },
+        },
+        y: {
+          ticks: {
+            callback: (value) => currencyFormat.format(Number(value)),
+            maxTicksLimit: 6,
+          },
+          grid: {
+            color: 'rgba(148, 163, 184, 0.15)',
+          },
+        },
+      },
+    } satisfies ChartOptions<'line'>;
+  }
+
+  private buildTradeTooltip(xValue: number | null): string | null {
+    if (!xValue) {
+      return null;
+    }
+    const trade = this.trades?.find((item) => new Date(item.timestamp).getTime() === xValue);
+    if (!trade) {
+      return null;
+    }
+    const priceFormatter = currencyFormatter(this.currency);
+    const sideLabel = trade.side === 'BUY' ? 'Kauf' : 'Verkauf';
+    const priceLabel = priceFormatter.format(trade.price);
+    const quantityLabel = new Intl.NumberFormat('de-DE', { maximumFractionDigits: 0 }).format(trade.quantity);
+    return `${sideLabel} ${quantityLabel} @ ${priceLabel} – ${tooltipDateFormatter.format(new Date(trade.timestamp))}`;
+  }
+}

--- a/boersencockpit/src/app/features/stocks/components/trade-form.css
+++ b/boersencockpit/src/app/features/stocks/components/trade-form.css
@@ -1,0 +1,7 @@
+:host {
+  display: block;
+}
+
+form {
+  background: transparent;
+}

--- a/boersencockpit/src/app/features/stocks/components/trade-form.html
+++ b/boersencockpit/src/app/features/stocks/components/trade-form.html
@@ -1,0 +1,118 @@
+<section class="space-y-6">
+  <header>
+    <h2 class="text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100" tabindex="-1">{{ heading }}</h2>
+    <p class="text-sm text-neutral-500 dark:text-neutral-400">Erfasse Kauf- oder Verkaufsorders mit validierten Eingaben.</p>
+  </header>
+  <div
+    *ngIf="formErrorMessages.length > 0"
+    class="rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800 dark:border-rose-700 dark:bg-rose-900/40 dark:text-rose-200"
+    aria-live="assertive"
+  >
+    <p class="font-medium">Bitte behebe die folgenden Fehler:</p>
+    <ul class="list-disc pl-5">
+      <li *ngFor="let error of formErrorMessages">{{ error }}</li>
+    </ul>
+  </div>
+  <form class="grid gap-4 md:grid-cols-2" [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+    <div class="space-y-1 md:col-span-1">
+      <label class="text-sm font-medium text-neutral-700 dark:text-neutral-200" for="trade-symbol">Symbol</label>
+      <input
+        id="trade-symbol"
+        type="text"
+        inputmode="latin"
+        autocomplete="off"
+        class="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm uppercase text-neutral-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:cursor-not-allowed disabled:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50"
+        formControlName="symbol"
+        [attr.aria-invalid]="controlHasError('symbol')"
+        [attr.aria-describedby]="controlHasError('symbol') ? 'trade-symbol-error' : null"
+        (input)="onSymbolInput($event)"
+      />
+      <p *ngIf="controlHasError('symbol')" id="trade-symbol-error" class="text-sm text-rose-600 dark:text-rose-400">
+        Bitte gib ein gültiges Symbol an.
+      </p>
+    </div>
+
+    <div class="space-y-1 md:col-span-1">
+      <label class="text-sm font-medium text-neutral-700 dark:text-neutral-200" for="trade-side">Richtung</label>
+      <select
+        id="trade-side"
+        class="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50"
+        formControlName="side"
+      >
+        <option value="BUY">Kauf</option>
+        <option value="SELL">Verkauf</option>
+      </select>
+    </div>
+
+    <div class="space-y-1 md:col-span-1">
+      <label class="text-sm font-medium text-neutral-700 dark:text-neutral-200" for="trade-quantity">Menge</label>
+      <input
+        id="trade-quantity"
+        type="number"
+        min="1"
+        step="1"
+        inputmode="numeric"
+        class="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50"
+        formControlName="quantity"
+        [attr.aria-invalid]="controlHasError('quantity')"
+        [attr.aria-describedby]="controlHasError('quantity') ? 'trade-quantity-error' : null"
+      />
+      <p *ngIf="controlHasError('quantity')" id="trade-quantity-error" class="text-sm text-rose-600 dark:text-rose-400">
+        Menge muss größer als 0 sein.
+      </p>
+    </div>
+
+    <div class="space-y-1 md:col-span-1">
+      <label class="text-sm font-medium text-neutral-700 dark:text-neutral-200" for="trade-price">Preis</label>
+      <input
+        id="trade-price"
+        type="number"
+        min="0"
+        step="0.01"
+        inputmode="decimal"
+        class="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50"
+        formControlName="price"
+        [attr.aria-invalid]="controlHasError('price')"
+        [attr.aria-describedby]="controlHasError('price') ? 'trade-price-error' : null"
+      />
+      <p *ngIf="controlHasError('price')" id="trade-price-error" class="text-sm text-rose-600 dark:text-rose-400">
+        Preis muss positiv sein und maximal zwei Nachkommastellen haben.
+      </p>
+    </div>
+
+    <div class="space-y-1 md:col-span-1">
+      <label class="text-sm font-medium text-neutral-700 dark:text-neutral-200" for="trade-timestamp">Datum &amp; Uhrzeit</label>
+      <input
+        id="trade-timestamp"
+        type="datetime-local"
+        class="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50"
+        formControlName="timestamp"
+        [attr.aria-invalid]="controlHasError('timestamp')"
+        [attr.aria-describedby]="controlHasError('timestamp') ? 'trade-timestamp-error' : null"
+      />
+      <p *ngIf="controlHasError('timestamp')" id="trade-timestamp-error" class="text-sm text-rose-600 dark:text-rose-400">
+        Datum muss in der Vergangenheit liegen.
+      </p>
+    </div>
+
+    <div class="space-y-1 md:col-span-1">
+      <label class="text-sm font-medium text-neutral-700 dark:text-neutral-200" for="trade-note">Notiz (optional)</label>
+      <textarea
+        id="trade-note"
+        rows="3"
+        class="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50"
+        formControlName="note"
+      ></textarea>
+    </div>
+
+    <div class="md:col-span-2 flex items-center justify-end gap-3">
+      <button
+        type="submit"
+        class="inline-flex items-center justify-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-neutral-400"
+        [disabled]="submitting"
+      >
+        {{ submitting ? 'Speichern…' : 'Speichern' }}
+      </button>
+    </div>
+  </form>
+</section>

--- a/boersencockpit/src/app/features/stocks/components/trade-form.ts
+++ b/boersencockpit/src/app/features/stocks/components/trade-form.ts
@@ -1,0 +1,109 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import { ReactiveFormsModule, NonNullableFormBuilder } from '@angular/forms';
+
+import {
+  TradeFormGroup,
+  TradeFormRawValue,
+  TradeFormValue,
+  buildTradeFormGroup,
+  parseTradeFormValue,
+} from '../forms/trade.schema';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+const toLocalDateTimeInput = (iso: string): string => {
+  const date = new Date(iso);
+  const tzOffset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - tzOffset).toISOString().slice(0, 16);
+};
+
+const toIsoString = (value: string): string => {
+  if (!value) {
+    return new Date().toISOString();
+  }
+  const hasTimezone = /Z$|[+-]\d{2}:\d{2}$/.test(value);
+  if (hasTimezone) {
+    return value;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date().toISOString();
+  }
+  return parsed.toISOString();
+};
+
+@Component({
+  selector: 'app-trade-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './trade-form.html',
+  styleUrl: './trade-form.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TradeFormComponent implements OnChanges {
+  private readonly formBuilder = inject(NonNullableFormBuilder);
+
+  @Input() symbol: Symbol | null = null;
+  @Input() submitting = false;
+  @Input() heading = 'Trade hinzufügen';
+
+  @Output() readonly submitted = new EventEmitter<TradeFormValue>();
+
+  protected readonly form: TradeFormGroup = buildTradeFormGroup(this.formBuilder);
+
+  constructor() {
+    const current = this.form.controls.timestamp.value;
+    this.form.controls.timestamp.setValue(toLocalDateTimeInput(current));
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['symbol']) {
+      const value = changes['symbol'].currentValue as Symbol | null;
+      if (value) {
+        this.form.controls.symbol.setValue(String(value));
+        this.form.controls.symbol.disable({ emitEvent: false });
+      } else {
+        this.form.controls.symbol.enable({ emitEvent: false });
+      }
+    }
+  }
+
+  protected onSymbolInput(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    const upper = target.value.toUpperCase();
+    this.form.controls.symbol.setValue(upper);
+  }
+
+  protected onSubmit(): void {
+    this.form.markAllAsTouched();
+    if (this.form.invalid) {
+      return;
+    }
+    const raw = this.form.getRawValue();
+    const normalized: TradeFormRawValue = {
+      ...raw,
+      timestamp: toIsoString(raw.timestamp),
+    };
+    const parsed = parseTradeFormValue(normalized);
+    this.submitted.emit(parsed);
+  }
+
+  protected controlHasError(controlName: keyof TradeFormGroup['controls']): boolean {
+    const control = this.form.controls[controlName];
+    return control.invalid && (control.dirty || control.touched);
+  }
+
+  protected get formErrorMessages(): readonly string[] {
+    const groupErrors = this.form.errors?.['zod'] as { message: string }[] | undefined;
+    return groupErrors?.map((error) => error.message) ?? [];
+  }
+}

--- a/boersencockpit/src/app/features/stocks/components/trade-table.css
+++ b/boersencockpit/src/app/features/stocks/components/trade-table.css
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+}
+
+table {
+  border-collapse: separate;
+  border-spacing: 0;
+}

--- a/boersencockpit/src/app/features/stocks/components/trade-table.html
+++ b/boersencockpit/src/app/features/stocks/components/trade-table.html
@@ -1,0 +1,56 @@
+<section class="space-y-4">
+  <header class="flex items-center justify-between">
+    <h2 class="text-lg font-semibold text-neutral-900 dark:text-neutral-100">Trades</h2>
+  </header>
+  <div class="overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
+    <table class="min-w-full table-auto text-left text-sm text-neutral-700 dark:text-neutral-200">
+      <thead class="sticky top-0 bg-neutral-50 text-xs uppercase tracking-wide text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+        <tr>
+          <th scope="col" class="px-4 py-3">Datum</th>
+          <th scope="col" class="px-4 py-3">Seite</th>
+          <th scope="col" class="px-4 py-3 text-right">Menge</th>
+          <th scope="col" class="px-4 py-3 text-right">Preis</th>
+          <th scope="col" class="px-4 py-3">Notiz</th>
+          <th scope="col" class="px-4 py-3 text-right">Aktionen</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngIf="trades.length === 0" class="text-neutral-500 dark:text-neutral-400">
+          <td colspan="6" class="px-4 py-6 text-center">Noch keine Trades erfasst.</td>
+        </tr>
+        <tr
+          *ngFor="let trade of trades; trackBy: trackByTrade"
+          class="border-t border-neutral-100 odd:bg-white even:bg-neutral-50 dark:border-neutral-800 dark:odd:bg-neutral-900 dark:even:bg-neutral-950"
+        >
+          <td class="px-4 py-3 align-top">{{ formatDate(trade.timestamp) }}</td>
+          <td class="px-4 py-3 align-top">
+            <span
+              class="inline-flex rounded-full px-2 py-1 text-xs font-semibold"
+              [ngClass]="{
+                'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300': trade.side === 'BUY',
+                'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300': trade.side === 'SELL'
+              }"
+            >
+              {{ trade.side === 'BUY' ? 'Kauf' : 'Verkauf' }}
+            </span>
+          </td>
+          <td class="px-4 py-3 text-right align-top font-mono">{{ trade.quantity | number:'1.0-0':'de-DE' }}</td>
+          <td class="px-4 py-3 text-right align-top font-mono">{{ trade.price | currency: currency:'symbol':'1.2-2':'de-DE' }}</td>
+          <td class="px-4 py-3 align-top">
+            <span *ngIf="trade.note; else noNote">{{ trade.note }}</span>
+            <ng-template #noNote>–</ng-template>
+          </td>
+          <td class="px-4 py-3 text-right align-top">
+            <button
+              type="button"
+              class="inline-flex items-center rounded-lg border border-rose-300 px-3 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 dark:border-rose-700 dark:text-rose-300 dark:hover:bg-rose-900/40"
+              (click)="onDelete(trade.id)"
+            >
+              Löschen
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/boersencockpit/src/app/features/stocks/components/trade-table.ts
+++ b/boersencockpit/src/app/features/stocks/components/trade-table.ts
@@ -1,0 +1,49 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { Trade } from '../../../domain/models/trade';
+
+const formatDateTime = (value: string): string =>
+  new Intl.DateTimeFormat('de-DE', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+
+@Component({
+  selector: 'app-trade-table',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './trade-table.html',
+  styleUrl: './trade-table.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TradeTableComponent {
+  private _trades: readonly Trade[] = [];
+
+  protected readonly formatDate = formatDateTime;
+  protected currency: 'EUR' | 'USD' | 'CHF' | 'GBP' = 'EUR';
+
+  @Input()
+  set trades(value: readonly Trade[] | null) {
+    this._trades = [...(value ?? [])].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  }
+
+  get trades(): readonly Trade[] {
+    return this._trades;
+  }
+
+  @Input()
+  set currencyCode(value: 'EUR' | 'USD' | 'CHF' | 'GBP') {
+    this.currency = value;
+  }
+
+  @Output() readonly delete = new EventEmitter<string>();
+
+  protected onDelete(id: string): void {
+    this.delete.emit(id);
+  }
+
+  protected trackByTrade(_index: number, trade: Trade): string {
+    return trade.id;
+  }
+}

--- a/boersencockpit/src/app/features/stocks/forms/trade.schema.spec.ts
+++ b/boersencockpit/src/app/features/stocks/forms/trade.schema.spec.ts
@@ -1,0 +1,90 @@
+import { FormBuilder } from '@angular/forms';
+
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { buildTradeFormGroup, parseTradeFormGroup, tradeFormSchema } from './trade.schema';
+
+const NOW = new Date('2024-01-10T10:00:00.000Z').getTime();
+
+describe('tradeFormSchema', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const baseInput = {
+    symbol: 'sap',
+    side: 'BUY' as const,
+    quantity: 5,
+    price: 120.5,
+    timestamp: '2024-01-10T09:00:00.000Z',
+    note: '  Erste Position  '
+  };
+
+  it('parses valid form input and normalises values', () => {
+    const result = tradeFormSchema.parse(baseInput);
+
+    expect(result.symbol).toEqual(asSymbol('SAP'));
+    expect(result.note).toBe('Erste Position');
+  });
+
+  it('rejects zero quantity', () => {
+    expect(() => tradeFormSchema.parse({ ...baseInput, quantity: 0 })).toThrow();
+  });
+
+  it('rejects negative price', () => {
+    expect(() => tradeFormSchema.parse({ ...baseInput, price: -1 })).toThrow();
+  });
+
+  it('rejects price with more than two decimals', () => {
+    expect(() => tradeFormSchema.parse({ ...baseInput, price: 1.239 })).toThrow();
+  });
+
+  it('rejects future timestamps', () => {
+    const futureTimestamp = new Date(NOW + 60_000).toISOString();
+    expect(() => tradeFormSchema.parse({ ...baseInput, timestamp: futureTimestamp })).toThrow();
+  });
+});
+
+describe('buildTradeFormGroup', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates a group with defaults and attaches zod validator', () => {
+    const formBuilder = new FormBuilder().nonNullable;
+    const group = buildTradeFormGroup(formBuilder);
+
+    expect(group.controls.quantity.value).toBe(1);
+
+    group.patchValue({ symbol: 'SAP', price: -1 });
+    group.updateValueAndValidity();
+
+    expect(group.invalid).toBe(true);
+    expect(group.errors?.['zod']?.[0].message).toBe('Preis muss größer oder gleich 0 sein.');
+  });
+
+  it('parses group value via parseTradeFormGroup', () => {
+    const formBuilder = new FormBuilder().nonNullable;
+    const group = buildTradeFormGroup(formBuilder, {
+      symbol: 'sap',
+      side: 'SELL',
+      quantity: 3,
+      price: 99.5,
+      timestamp: '2024-01-10T08:30:00.000Z',
+      note: '  Teilverkauf '
+    });
+
+    const parsed = parseTradeFormGroup(group);
+
+    expect(parsed.side).toBe('SELL');
+    expect(parsed.symbol).toEqual(asSymbol('SAP'));
+    expect(parsed.note).toBe('Teilverkauf');
+  });
+});

--- a/boersencockpit/src/app/features/stocks/forms/trade.schema.ts
+++ b/boersencockpit/src/app/features/stocks/forms/trade.schema.ts
@@ -1,0 +1,118 @@
+import {
+  NonNullableFormBuilder,
+  Validators,
+  FormControl,
+  FormGroup,
+  ValidationErrors,
+  ValidatorFn
+} from '@angular/forms';
+import { z } from 'zod';
+
+import { isoStringSchema } from '../../../domain/schemas/common';
+import { symbolSchema } from '../../../domain/schemas/symbol.schema';
+
+const PRICE_DECIMAL_FACTOR = 100;
+
+const priceHasTwoDecimals = (value: number) =>
+  Number.isFinite(value) && Math.abs(Math.round(value * PRICE_DECIMAL_FACTOR) - value * PRICE_DECIMAL_FACTOR) < 1e-6;
+
+const notePreprocessor = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : value;
+
+export const tradeFormSchema = z.object({
+  symbol: z
+    .string({ required_error: 'Symbol darf nicht leer sein.' })
+    .trim()
+    .min(1, 'Symbol darf nicht leer sein.')
+    .transform((value) => value.toUpperCase())
+    .pipe(symbolSchema),
+  side: z.enum(['BUY', 'SELL']),
+  quantity: z
+    .number({ invalid_type_error: 'Menge muss eine Zahl sein.' })
+    .int('Menge muss eine ganze Zahl sein.')
+    .min(1, 'Menge muss größer als 0 sein.'),
+  price: z
+    .number({ invalid_type_error: 'Preis muss eine Zahl sein.' })
+    .min(0, 'Preis muss größer oder gleich 0 sein.')
+    .refine(priceHasTwoDecimals, 'Preis darf maximal zwei Nachkommastellen haben.'),
+  timestamp: isoStringSchema.refine(
+    (value) => new Date(value).getTime() <= Date.now(),
+    'Zeitstempel darf nicht in der Zukunft liegen.'
+  ),
+  note: z
+    .preprocess(notePreprocessor, z.string().max(500, 'Notiz darf maximal 500 Zeichen enthalten.'))
+    .optional()
+    .transform((value) => (value ? value : undefined))
+});
+
+export type TradeFormSchema = typeof tradeFormSchema;
+export type TradeFormRawValue = z.input<TradeFormSchema>;
+export type TradeFormValue = z.output<TradeFormSchema>;
+
+export type TradeFormGroupControls = {
+  readonly symbol: FormControl<string>;
+  readonly side: FormControl<'BUY' | 'SELL'>;
+  readonly quantity: FormControl<number>;
+  readonly price: FormControl<number>;
+  readonly timestamp: FormControl<string>;
+  readonly note: FormControl<string>;
+};
+
+export type TradeFormGroup = FormGroup<TradeFormGroupControls>;
+
+const createZodGroupValidator = (schema: TradeFormSchema): ValidatorFn => {
+  return (control) => {
+    const value = control instanceof FormGroup ? control.getRawValue() : control.value;
+    const result = schema.safeParse(value);
+    if (result.success) {
+      return null;
+    }
+
+    return {
+      zod: result.error.issues.map((issue) => ({
+        path: issue.path.join('.'),
+        message: issue.message
+      }))
+    } satisfies ValidationErrors;
+  };
+};
+
+const defaultTradeFormValue = (): TradeFormRawValue => ({
+  symbol: '',
+  side: 'BUY',
+  quantity: 1,
+  price: 0,
+  timestamp: new Date().toISOString(),
+  note: ''
+});
+
+export const buildTradeFormGroup = (
+  formBuilder: NonNullableFormBuilder,
+  initialValue?: Partial<TradeFormRawValue>
+): TradeFormGroup => {
+  const rawValue = { ...defaultTradeFormValue(), ...initialValue } satisfies TradeFormRawValue;
+  const noteValue = typeof rawValue.note === 'string' ? rawValue.note : '';
+  const group = formBuilder.group<TradeFormGroupControls>({
+    symbol: formBuilder.control<string>(rawValue.symbol, {
+      validators: [Validators.required, Validators.pattern(/^[A-Za-z0-9.-]+$/)]
+    }),
+    side: formBuilder.control<'BUY' | 'SELL'>(rawValue.side),
+    quantity: formBuilder.control<number>(rawValue.quantity, {
+      validators: [Validators.required, Validators.min(1)]
+    }),
+    price: formBuilder.control<number>(rawValue.price, {
+      validators: [Validators.required, Validators.min(0)]
+    }),
+    timestamp: formBuilder.control<string>(rawValue.timestamp, { validators: [Validators.required] }),
+    note: formBuilder.control<string>(noteValue)
+  });
+
+  group.addValidators(createZodGroupValidator(tradeFormSchema));
+
+  return group;
+};
+
+export const parseTradeFormValue = (value: TradeFormRawValue): TradeFormValue => tradeFormSchema.parse(value);
+
+export const parseTradeFormGroup = (group: TradeFormGroup): TradeFormValue =>
+  tradeFormSchema.parse(group.getRawValue());

--- a/boersencockpit/src/app/features/stocks/pages/stock-add.page.html
+++ b/boersencockpit/src/app/features/stocks/pages/stock-add.page.html
@@ -1,10 +1,18 @@
-<section class="space-y-4">
-  <h1 class="text-2xl font-semibold tracking-tight" tabindex="-1">Aktie hinzufügen</h1>
-  <p class="text-sm text-neutral-600 dark:text-neutral-300">
-    Dieses Formular nimmt in einer späteren Phase die Daten für neue Aktien auf. Hier zeigen wir den reservierten Bereich und die
-    kommenden Interaktionspunkte.
+<section class="space-y-6">
+  <header class="space-y-2">
+    <h1 class="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100" tabindex="-1">Aktie &amp; Trades erfassen</h1>
+    <p class="text-sm text-neutral-500 dark:text-neutral-400">
+      Ergänze deine Watchlist mit neuen Positionen. Alle Eingaben werden in Echtzeit validiert.
+    </p>
+  </header>
+
+  <p *ngIf="liveMessage()" class="rounded-lg bg-emerald-100 px-4 py-2 text-sm text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200" aria-live="polite">
+    {{ liveMessage() }}
   </p>
-  <div class="rounded-lg border border-dashed border-neutral-300 p-6 text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
-    Formularplatzhalter – Eingabe- und Validierungslogik folgen.
-  </div>
+
+  <app-trade-form [heading]="'Trade anlegen'" [submitting]="submitting()" (submitted)="handleSubmit($event)"></app-trade-form>
+
+  <p class="text-xs text-neutral-500 dark:text-neutral-400">
+    Hinweis: Trades werden lokal gespeichert. Erfolgreiche Buchungen führen dich automatisch zur passenden Ansicht.
+  </p>
 </section>

--- a/boersencockpit/src/app/features/stocks/pages/stock-add.page.ts
+++ b/boersencockpit/src/app/features/stocks/pages/stock-add.page.ts
@@ -1,12 +1,82 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, inject, signal } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { Actions, ofType } from '@ngrx/effects';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { firstValueFrom, map, take } from 'rxjs';
+
+import { TradeFormComponent } from '../components/trade-form';
+import { TradeFormValue } from '../forms/trade.schema';
+import * as TradesActions from '../../trades/state/trades.actions';
+import { selectStockBySymbol } from '../state/stocks.selectors';
+import { Symbol } from '../../../domain/models/symbol.brand';
 
 @Component({
   selector: 'app-stock-add-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink, TradeFormComponent],
   templateUrl: './stock-add.page.html',
   styleUrl: './stock-add.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class StockAddPageComponent {}
+export class StockAddPageComponent implements OnDestroy {
+  private readonly store = inject(Store);
+  private readonly router = inject(Router);
+  private readonly actions$ = inject(Actions);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private pendingSubmission: { id: string; symbol: Symbol; existed: boolean } | null = null;
+
+  readonly submitting = signal(false);
+  readonly liveMessage = signal('');
+
+  constructor() {
+    this.actions$
+      .pipe(ofType(TradesActions.addTradeSucceeded), takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ trade }) => {
+        if (this.pendingSubmission?.id !== trade.id) {
+          return;
+        }
+        this.submitting.set(false);
+        this.liveMessage.set('Trade erfolgreich gespeichert.');
+        const target = this.pendingSubmission.existed ? ['/stocks', trade.symbol] : ['/stocks'];
+        this.router.navigate(target);
+        this.pendingSubmission = null;
+      });
+
+    this.actions$
+      .pipe(ofType(TradesActions.addTradeFailed), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.submitting.set(false);
+        this.liveMessage.set('Speichern fehlgeschlagen. Bitte Eingaben prüfen.');
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.liveMessage.set('');
+  }
+
+  async handleSubmit(value: TradeFormValue): Promise<void> {
+    const id = crypto.randomUUID();
+    const existed = await firstValueFrom(
+      this.store
+        .select(selectStockBySymbol(value.symbol))
+        .pipe(
+          take(1),
+          map((existing) => Boolean(existing))
+        )
+    );
+
+    this.pendingSubmission = { id, symbol: value.symbol, existed };
+    this.submitting.set(true);
+    this.store.dispatch(
+      TradesActions.addTradeRequested({
+        tradeInput: {
+          id,
+          ...value,
+        },
+      })
+    );
+  }
+}

--- a/boersencockpit/src/app/features/stocks/pages/stock-detail.page.html
+++ b/boersencockpit/src/app/features/stocks/pages/stock-detail.page.html
@@ -1,9 +1,103 @@
-<section class="space-y-4">
-  <h1 class="text-2xl font-semibold tracking-tight" tabindex="-1">Details zu {{ symbol$ | async }}</h1>
-  <p class="text-sm text-neutral-600 dark:text-neutral-300">
-    Detaillierte Kennzahlen, Kursverläufe und Nachrichten erscheinen hier in einer späteren Phase.
-  </p>
-  <div class="rounded-lg border border-dashed border-neutral-300 p-6 text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
-    Platzhalter für Aktien-spezifische Inhalte.
+<section *ngIf="viewModel$ | async as vm" class="space-y-8">
+  <header class="space-y-2">
+    <h1 class="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100" tabindex="-1">
+      {{ vm.symbol }} – Detail
+    </h1>
+    <p class="text-sm text-neutral-500 dark:text-neutral-400">{{ vm.stockName || 'Unbekannter Titel' }}</p>
+  </header>
+
+  <div class="grid gap-4 md:grid-cols-3">
+    <div class="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">Aktueller Preis</p>
+      <p class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+        <ng-container *ngIf="vm.quote; else priceFallback">
+          {{ vm.quote.price | currency: vm.currency:'symbol':'1.2-2':'de-DE' }}
+        </ng-container>
+      </p>
+      <ng-template #priceFallback>–</ng-template>
+      <p *ngIf="vm.quote" class="text-sm" [ngClass]="vm.quote.changePct >= 0 ? 'text-emerald-600' : 'text-rose-600'">
+        {{ vm.quote.changeAbs | currency: vm.currency:'symbol':'1.2-2':'de-DE' }}
+        ({{ (vm.quote.changePct / 100) | percent:'1.2-2':'de-DE' }})
+      </p>
+    </div>
+    <div class="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">Nettomenge</p>
+      <p class="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">
+        {{ vm.netQuantity | number:'1.0-0':'de-DE' }}
+      </p>
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">Durchschnittlicher Einstand</p>
+      <p class="text-lg text-neutral-800 dark:text-neutral-200">
+        {{ vm.avgPrice ? (vm.avgPrice | currency: vm.currency:'symbol':'1.2-2':'de-DE') : '–' }}
+      </p>
+    </div>
+    <div class="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">Unrealisierter P&amp;L</p>
+      <p
+        class="text-2xl font-semibold"
+        [ngClass]="{
+          'text-emerald-600': (vm.unrealized ?? 0) >= 0,
+          'text-rose-600': (vm.unrealized ?? 0) < 0,
+          'text-neutral-900 dark:text-neutral-100': vm.unrealized === null
+        }"
+      >
+        {{ vm.unrealized !== null ? (vm.unrealized | currency: vm.currency:'symbol':'1.2-2':'de-DE') : '–' }}
+      </p>
+      <p class="text-sm text-neutral-500 dark:text-neutral-400">basierend auf aktuellen Kursen</p>
+    </div>
+  </div>
+
+  <app-timeseries-chart
+    [series]="vm.series"
+    [trades]="vm.trades"
+    [range]="range()"
+    [currency]="vm.currency"
+    [loading]="vm.loading"
+    [error]="vm.error"
+    (rangeChange)="handleRangeChange($event)"
+    (retryRequested)="retry(vm.symbol)"
+  ></app-timeseries-chart>
+
+  <div class="grid gap-8 lg:grid-cols-[minmax(0,360px)_1fr]">
+    <div class="rounded-2xl border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-900">
+      <app-trade-form [symbol]="vm.symbol" [heading]="'Trade hinzufügen'" (submitted)="handleTradeSubmit($event)"></app-trade-form>
+    </div>
+    <div class="rounded-2xl border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-900">
+      <app-trade-table [trades]="vm.trades" [currencyCode]="vm.currency" (delete)="handleDeleteRequest($event, vm.trades)"></app-trade-table>
+    </div>
   </div>
 </section>
+
+<ng-container *ngIf="pendingDelete() as trade">
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="presentation">
+    <div
+      class="w-full max-w-sm rounded-2xl border border-neutral-200 bg-white p-6 shadow-xl dark:border-neutral-700 dark:bg-neutral-900"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-trade-title"
+      [appFocusTrap]="true"
+    >
+      <div class="space-y-3">
+        <h2 id="delete-trade-title" class="text-lg font-semibold text-neutral-900 dark:text-neutral-100">Trade löschen?</h2>
+        <p class="text-sm text-neutral-500 dark:text-neutral-400">
+          Der Trade vom {{ trade.timestamp | date:'medium':'de-DE' }} über {{ trade.quantity }} Stück wird dauerhaft entfernt.
+        </p>
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="rounded-lg border border-neutral-300 px-3 py-1.5 text-sm font-semibold text-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:border-neutral-600 dark:text-neutral-200"
+            (click)="closeDialog()"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            class="rounded-lg bg-rose-600 px-3 py-1.5 text-sm font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400"
+            (click)="confirmDelete()"
+          >
+            Löschen
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</ng-container>

--- a/boersencockpit/src/app/features/stocks/pages/stock-detail.page.spec.ts
+++ b/boersencockpit/src/app/features/stocks/pages/stock-detail.page.spec.ts
@@ -1,0 +1,103 @@
+import { DestroyRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+
+jest.mock('ng2-charts', () => ({
+  BaseChartDirective: class {},
+}));
+
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    ...(globalThis as any).crypto,
+    randomUUID: () => 'test-id',
+  },
+  configurable: true,
+});
+
+import { StockDetailPageComponent } from './stock-detail.page';
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { ListSymbol } from '../../../core/api/price-api.port';
+import { PriceQuote } from '../../../domain/models/quote';
+import { TradeFormValue } from '../forms/trade.schema';
+import * as TimeSeriesActions from '../../timeseries/state/timeseries.actions';
+import * as TradesActions from '../../trades/state/trades.actions';
+import { selectStockBySymbol } from '../state/stocks.selectors';
+import { selectQuoteBySymbol } from '../../quotes/state/quotes.selectors';
+import { selectTradesBySymbol, selectPositions } from '../../trades/state/trades.selectors';
+import { selectTimeSeries, selectTimeSeriesError, selectTimeSeriesLoading } from '../../timeseries/state/timeseries.selectors';
+import { TimeSeries } from '../../../domain/models/candle';
+
+describe('StockDetailPageComponent', () => {
+  let component: StockDetailPageComponent;
+  let store: MockStore;
+
+  const symbol = asSymbol('SAP');
+  const listSymbol: ListSymbol = { symbol, name: 'SAP SE', currency: 'EUR' };
+  const quote: PriceQuote = {
+    symbol,
+    price: 120,
+    changeAbs: 2,
+    changePct: 1.8,
+    asOf: '2024-01-01T00:00:00.000Z',
+  };
+  const series: TimeSeries = { symbol, candles: [] };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({
+          selectors: [
+            { selector: selectStockBySymbol(symbol), value: listSymbol },
+            { selector: selectQuoteBySymbol(symbol), value: quote },
+            { selector: selectTradesBySymbol(symbol), value: [] },
+            { selector: selectPositions, value: [] },
+            { selector: selectTimeSeries(symbol, '1M'), value: series },
+            { selector: selectTimeSeriesLoading(symbol, '1M'), value: false },
+            { selector: selectTimeSeriesError(symbol, '1M'), value: null },
+          ],
+        }),
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: of(convertToParamMap({ symbol: 'SAP' })) },
+        },
+        {
+          provide: DestroyRef,
+          useValue: { onDestroy: () => undefined },
+        },
+      ],
+    });
+    store = TestBed.inject(MockStore);
+    jest.spyOn(store, 'dispatch');
+    component = TestBed.runInInjectionContext(() => new StockDetailPageComponent());
+  });
+
+  it('dispatches time series request when range changes', async () => {
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+    dispatchSpy.mockClear();
+    component['handleRangeChange']('1W');
+    await Promise.resolve();
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      TimeSeriesActions.timeSeriesRequested({ symbol, range: '1W' })
+    );
+  });
+
+  it('dispatches addTradeRequested when submitting a trade', () => {
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+    dispatchSpy.mockClear();
+    component['handleTradeSubmit']({
+      symbol,
+      side: 'BUY',
+      quantity: 1,
+      price: 100,
+      timestamp: '2024-01-01T00:00:00.000Z',
+    } as TradeFormValue);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: TradesActions.addTradeRequested.type,
+        tradeInput: expect.objectContaining({ symbol }),
+      })
+    );
+  });
+});

--- a/boersencockpit/src/app/features/stocks/pages/stock-detail.page.ts
+++ b/boersencockpit/src/app/features/stocks/pages/stock-detail.page.ts
@@ -1,18 +1,175 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { map } from 'rxjs';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { combineLatest, distinctUntilChanged, map, switchMap } from 'rxjs';
+
+import { asSymbol, Symbol } from '../../../domain/models/symbol.brand';
+import { selectStockBySymbol } from '../state/stocks.selectors';
+import { selectQuoteBySymbol } from '../../quotes/state/quotes.selectors';
+import { selectTradesBySymbol, selectPositions } from '../../trades/state/trades.selectors';
+import { selectTimeSeries, selectTimeSeriesError, selectTimeSeriesLoading } from '../../timeseries/state/timeseries.selectors';
+import * as TimeSeriesActions from '../../timeseries/state/timeseries.actions';
+import * as QuotesActions from '../../quotes/state/quotes.actions';
+import { RangeKey } from '../../../core/api/price-api.port';
+import { TimeseriesChartComponent } from '../components/timeseries-chart';
+import { TradeFormComponent } from '../components/trade-form';
+import { TradeTableComponent } from '../components/trade-table';
+import { TradeFormValue } from '../forms/trade.schema';
+import * as TradesActions from '../../trades/state/trades.actions';
+import { Trade } from '../../../domain/models/trade';
+import { FocusTrapDirective } from '../../../layout/accessibility/focus-trap.directive';
+import { PriceQuote } from '../../../domain/models/quote';
+import { TimeSeries } from '../../../domain/models/candle';
+
+interface DetailViewModel {
+  readonly symbol: Symbol;
+  readonly stockName: string | null;
+  readonly currency: 'EUR' | 'USD' | 'CHF' | 'GBP';
+  readonly quote: PriceQuote | null;
+  readonly trades: readonly Trade[];
+  readonly netQuantity: number;
+  readonly avgPrice: number | null;
+  readonly unrealized: number | null;
+  readonly series: TimeSeries | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+const DEFAULT_RANGE: RangeKey = '1M';
 
 @Component({
   selector: 'app-stock-detail-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterLink, TimeseriesChartComponent, TradeFormComponent, TradeTableComponent, FocusTrapDirective],
   templateUrl: './stock-detail.page.html',
   styleUrl: './stock-detail.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class StockDetailPageComponent {
-  readonly symbol$ = this.route.paramMap.pipe(map((params) => params.get('symbol') ?? 'Unbekannt'));
+export class StockDetailPageComponent implements OnInit, OnDestroy {
+  private readonly store = inject(Store);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
 
-  constructor(private readonly route: ActivatedRoute) {}
+  private readonly routeSymbol$ = this.route.paramMap.pipe(
+    map((params) => params.get('symbol') ?? ''),
+    map((value) => asSymbol(value.toUpperCase())),
+    distinctUntilChanged()
+  );
+
+  readonly range = signal<RangeKey>(DEFAULT_RANGE);
+  private readonly range$ = toObservable(this.range);
+
+  private readonly stock$ = this.routeSymbol$.pipe(switchMap((symbol) => this.store.select(selectStockBySymbol(symbol))));
+  private readonly quote$ = this.routeSymbol$.pipe(switchMap((symbol) => this.store.select(selectQuoteBySymbol(symbol))));
+  private readonly trades$ = this.routeSymbol$.pipe(switchMap((symbol) => this.store.select(selectTradesBySymbol(symbol))));
+  private readonly position$ = combineLatest([this.store.select(selectPositions), this.routeSymbol$]).pipe(
+    map(([positions, symbol]) => positions.find((position) => position.symbol === symbol) ?? null)
+  );
+  private readonly series$ = combineLatest([this.routeSymbol$, this.range$]).pipe(
+    switchMap(([symbol, range]) => this.store.select(selectTimeSeries(symbol, range)))
+  );
+  private readonly seriesLoading$ = combineLatest([this.routeSymbol$, this.range$]).pipe(
+    switchMap(([symbol, range]) => this.store.select(selectTimeSeriesLoading(symbol, range))),
+    distinctUntilChanged()
+  );
+  private readonly seriesError$ = combineLatest([this.routeSymbol$, this.range$]).pipe(
+    switchMap(([symbol, range]) => this.store.select(selectTimeSeriesError(symbol, range)))
+  );
+
+  readonly viewModel$ = combineLatest([
+    this.routeSymbol$,
+    this.stock$,
+    this.quote$,
+    this.trades$,
+    this.position$,
+    this.series$,
+    this.seriesLoading$,
+    this.seriesError$,
+  ]).pipe(
+    map(([symbol, stock, quote, trades, position, series, loading, error]): DetailViewModel => {
+      const currency = stock?.currency ?? 'EUR';
+      const netQuantity = position?.totalQuantity ?? 0;
+      const avgPrice = position?.avgBuyPrice ?? null;
+      const unrealized = quote && avgPrice && netQuantity > 0 ? (quote.price - avgPrice) * netQuantity : null;
+      return {
+        symbol,
+        stockName: stock?.name ?? null,
+        currency,
+        quote: quote ?? null,
+        trades,
+        netQuantity,
+        avgPrice,
+        unrealized,
+        series,
+        loading,
+        error: error?.message ?? null,
+      };
+    })
+  );
+
+  readonly pendingDelete = signal<Trade | null>(null);
+
+  constructor() {
+    combineLatest([this.routeSymbol$, this.range$])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([symbol, range]) => {
+        this.store.dispatch(TimeSeriesActions.timeSeriesRequested({ symbol, range }));
+      });
+
+    this.routeSymbol$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((symbol) => {
+        this.store.dispatch(QuotesActions.quotesPollStop());
+        this.store.dispatch(QuotesActions.quotesSnapshotRequested({ symbols: [symbol] }));
+        this.store.dispatch(QuotesActions.quotesPollStart({ symbols: [symbol] }));
+      });
+  }
+
+  ngOnInit(): void {
+    // Ensure default data load when entering the page.
+  }
+
+  ngOnDestroy(): void {
+    this.store.dispatch(QuotesActions.quotesPollStop());
+  }
+
+  protected handleRangeChange(range: RangeKey): void {
+    this.range.set(range);
+  }
+
+  protected async handleTradeSubmit(value: TradeFormValue): Promise<void> {
+    const id = crypto.randomUUID();
+    this.store.dispatch(
+      TradesActions.addTradeRequested({
+        tradeInput: {
+          id,
+          ...value,
+        },
+      })
+    );
+  }
+
+  protected handleDeleteRequest(tradeId: string, trades: readonly Trade[]): void {
+    const trade = trades.find((item) => item.id === tradeId) ?? null;
+    this.pendingDelete.set(trade);
+  }
+
+  protected closeDialog(): void {
+    this.pendingDelete.set(null);
+  }
+
+  protected confirmDelete(): void {
+    const trade = this.pendingDelete();
+    if (!trade) {
+      return;
+    }
+    this.store.dispatch(TradesActions.removeTradeRequested({ id: trade.id }));
+    this.pendingDelete.set(null);
+  }
+
+  protected retry(symbol: Symbol): void {
+    this.store.dispatch(TimeSeriesActions.timeSeriesRequested({ symbol, range: this.range() }));
+  }
 }

--- a/boersencockpit/src/app/features/stocks/pages/stocks-list.page.html
+++ b/boersencockpit/src/app/features/stocks/pages/stocks-list.page.html
@@ -1,9 +1,60 @@
-<section class="space-y-4">
-  <h1 class="text-2xl font-semibold tracking-tight" tabindex="-1">Aktienüberblick</h1>
-  <p class="text-sm text-neutral-600 dark:text-neutral-300">
-    Hier entsteht der Überblick über alle beobachteten Aktien. In späteren Phasen folgen Kursdaten, Filter und Schnellaktionen.
-  </p>
-  <div class="rounded-lg border border-dashed border-neutral-300 p-4 text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
-    Platzhalterliste für Aktien – Datenintegration folgt in Phase 5.
+<section class="space-y-6">
+  <header class="space-y-2">
+    <h1 class="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100" tabindex="-1">Aktienüberblick</h1>
+    <p class="text-sm text-neutral-500 dark:text-neutral-400">Verfolge deine beobachteten Symbole, aktuelle Kurse und Tagesperformance.</p>
+  </header>
+
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <label class="flex-1 min-w-[220px]">
+      <span class="sr-only">Aktien filtern</span>
+      <input
+        type="search"
+        [formControl]="searchControl"
+        placeholder="Aktien filtern"
+        class="w-full rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm text-neutral-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50"
+        aria-label="Aktien filtern"
+      />
+    </label>
+    <a
+      routerLink="/stocks/add"
+      class="inline-flex items-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+    >
+      Aktie hinzufügen
+    </a>
   </div>
+
+  <ng-container *ngIf="(filteredStocks$ | async) as stocks; else loadingState">
+    <ng-container *ngIf="stocks.length > 0; else emptyState">
+      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <app-stock-list-item
+          *ngFor="let item of stocks; trackBy: trackBySymbol"
+          [symbol]="item.listSymbol.symbol"
+          [name]="item.listSymbol.name"
+          [currency]="item.listSymbol.currency"
+          [quote]="item.quote"
+        ></app-stock-list-item>
+      </div>
+    </ng-container>
+  </ng-container>
+
+  <ng-template #loadingState>
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <div *ngFor="let skeleton of [1,2,3,4,5,6]" class="rounded-xl border border-dashed border-neutral-300 p-6 dark:border-neutral-700">
+        <div class="flex h-24 items-center justify-center text-sm text-neutral-400">Lade Symbole…</div>
+      </div>
+    </div>
+  </ng-template>
+
+  <ng-template #emptyState>
+    <div class="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-neutral-300 bg-neutral-50 p-10 text-center text-neutral-500 dark:border-neutral-700 dark:bg-neutral-900/40 dark:text-neutral-300">
+      <p class="text-lg font-medium">Noch keine Aktien beobachtet.</p>
+      <p class="text-sm">Starte deine Watchlist, indem du eine Aktie hinzufügst.</p>
+      <a
+        routerLink="/stocks/add"
+        class="inline-flex items-center rounded-lg border border-primary-500 px-4 py-2 text-sm font-semibold text-primary-600 transition hover:bg-primary-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:border-primary-400 dark:text-primary-300 dark:hover:bg-primary-900/40"
+      >
+        Aktie hinzufügen
+      </a>
+    </div>
+  </ng-template>
 </section>

--- a/boersencockpit/src/app/features/stocks/pages/stocks-list.page.spec.ts
+++ b/boersencockpit/src/app/features/stocks/pages/stocks-list.page.spec.ts
@@ -1,0 +1,75 @@
+import { DestroyRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { firstValueFrom } from 'rxjs';
+import { skip } from 'rxjs/operators';
+
+import { StocksListPageComponent } from './stocks-list.page';
+import { ListSymbol } from '../../../core/api/price-api.port';
+import { asSymbol } from '../../../domain/models/symbol.brand';
+import { PriceQuote } from '../../../domain/models/quote';
+import { selectAllStocks } from '../state/stocks.selectors';
+import { selectQuotesEntities } from '../../quotes/state/quotes.selectors';
+
+const symbols: ListSymbol[] = [
+  { symbol: asSymbol('SAP'), name: 'SAP SE', currency: 'EUR' },
+  { symbol: asSymbol('MSFT'), name: 'Microsoft', currency: 'USD' },
+];
+
+const quotes: Record<string, PriceQuote> = {
+  [symbols[0].symbol]: {
+    symbol: symbols[0].symbol,
+    price: 120,
+    changeAbs: 2,
+    changePct: 1.8,
+    asOf: '2024-01-01T00:00:00.000Z',
+  },
+  [symbols[1].symbol]: {
+    symbol: symbols[1].symbol,
+    price: 300,
+    changeAbs: -5,
+    changePct: -1.1,
+    asOf: '2024-01-01T00:00:00.000Z',
+  },
+};
+
+describe('StocksListPageComponent', () => {
+  let component: StocksListPageComponent;
+  let store: MockStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({
+          selectors: [
+            { selector: selectAllStocks, value: symbols },
+            { selector: selectQuotesEntities, value: quotes },
+          ],
+        }),
+        {
+          provide: DestroyRef,
+          useValue: {
+            onDestroy: () => undefined,
+          },
+        },
+      ],
+    });
+    store = TestBed.inject(MockStore);
+    jest.spyOn(store, 'dispatch');
+    component = TestBed.runInInjectionContext(() => new StocksListPageComponent());
+  });
+
+  it('provides filtered stocks with matching quotes', async () => {
+    const result = await firstValueFrom(component.filteredStocks$);
+    expect(result).toHaveLength(2);
+    expect(result[0].quote?.price).toBe(120);
+  });
+
+  it('filters stocks by search term', async () => {
+    const resultPromise = firstValueFrom(component.filteredStocks$.pipe(skip(1)));
+    component.searchControl.setValue('sap');
+    const result = await resultPromise;
+    expect(result).toHaveLength(1);
+    expect(result[0].listSymbol.symbol).toEqual(symbols[0].symbol);
+  });
+});

--- a/boersencockpit/src/app/features/stocks/pages/stocks-list.page.ts
+++ b/boersencockpit/src/app/features/stocks/pages/stocks-list.page.ts
@@ -1,12 +1,100 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, OnInit, inject } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { combineLatest, map, startWith, distinctUntilChanged } from 'rxjs';
+
+import { StockListItemComponent } from '../components/stock-list-item';
+import * as StocksActions from '../state/stocks.actions';
+import { selectAllStocks } from '../state/stocks.selectors';
+import { selectQuotesEntities } from '../../quotes/state/quotes.selectors';
+import * as QuotesActions from '../../quotes/state/quotes.actions';
+import { ListSymbol } from '../../../core/api/price-api.port';
+import { PriceQuote } from '../../../domain/models/quote';
+import { Symbol } from '../../../domain/models/symbol.brand';
+
+interface StockListItemViewModel {
+  readonly listSymbol: ListSymbol;
+  readonly quote: PriceQuote | null;
+}
+
+const symbolsEqual = (prev: readonly Symbol[], next: readonly Symbol[]): boolean => {
+  if (prev.length !== next.length) {
+    return false;
+  }
+  return prev.every((symbol, index) => symbol === next[index]);
+};
 
 @Component({
   selector: 'app-stocks-list-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, StockListItemComponent],
   templateUrl: './stocks-list.page.html',
   styleUrl: './stocks-list.page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class StocksListPageComponent {}
+export class StocksListPageComponent implements OnInit, OnDestroy {
+  private readonly store = inject(Store);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly searchControl = new FormControl('', { nonNullable: true });
+
+  private readonly symbols$ = this.store.select(selectAllStocks);
+  private readonly quotes$ = this.store.select(selectQuotesEntities);
+
+  readonly filteredStocks$ = combineLatest([
+    this.symbols$,
+    this.quotes$,
+    this.searchControl.valueChanges.pipe(startWith('')),
+  ]).pipe(
+    map(([symbols, quotes, search]) => {
+      const term = search.trim().toLowerCase();
+      const filtered = symbols.filter((symbol) => {
+        if (!term) {
+          return true;
+        }
+        return (
+          symbol.symbol.toLowerCase().includes(term) ||
+          symbol.name.toLowerCase().includes(term)
+        );
+      });
+      return filtered.map<StockListItemViewModel>((listSymbol) => ({
+        listSymbol,
+        quote: quotes[listSymbol.symbol] ?? null,
+      }));
+    })
+  );
+
+  readonly hasSymbols$ = this.symbols$.pipe(map((symbols) => symbols.length > 0));
+
+  constructor() {
+    this.filteredStocks$
+      .pipe(
+        map((items) => items.map(({ listSymbol }) => listSymbol.symbol)),
+        distinctUntilChanged(symbolsEqual),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((symbols) => {
+        if (symbols.length === 0) {
+          this.store.dispatch(QuotesActions.quotesPollStop());
+          return;
+        }
+        this.store.dispatch(QuotesActions.quotesSnapshotRequested({ symbols }));
+        this.store.dispatch(QuotesActions.quotesPollStart({ symbols }));
+      });
+  }
+
+  ngOnInit(): void {
+    this.store.dispatch(StocksActions.loadSymbolsRequested());
+  }
+
+  ngOnDestroy(): void {
+    this.store.dispatch(QuotesActions.quotesPollStop());
+  }
+
+  protected trackBySymbol(_index: number, item: StockListItemViewModel): Symbol {
+    return item.listSymbol.symbol;
+  }
+}


### PR DESCRIPTION
## Summary
- build stocks list, add, and detail standalone pages wired to NgRx selectors/actions for quotes, trades, and time series data
- create reusable trade form/table and time series chart components with Chart.js annotation plugin registration and Tailwind styling
- add Jest and Cypress coverage for stocks flows and extend dependencies for chart rendering

## Testing
- npm run test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d691a1e2c08321b2e29ee67ebc5fb7