### PR TITLE
Fix environment types and add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: boersencockpit/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: boersencockpit
+
+      - name: Run production build
+        run: npm run build -- --configuration=production
+        working-directory: boersencockpit

--- a/boersencockpit/src/environments/environment.model.ts
+++ b/boersencockpit/src/environments/environment.model.ts
@@ -1,0 +1,16 @@
+export type DataSource = 'mock' | 'alpha';
+
+export interface AlphaVantageEnvironmentConfig {
+  readonly apiKey: string;
+  readonly baseUrl: string;
+  readonly maxRequestsPerMinute: number;
+  readonly minRequestSpacingMs: number;
+  readonly cacheTtlMs: number;
+  readonly enablePersistentCache: boolean;
+}
+
+export interface Environment {
+  readonly production: boolean;
+  readonly dataSource: DataSource;
+  readonly alphaVantage: AlphaVantageEnvironmentConfig;
+}

--- a/boersencockpit/src/environments/environment.production.ts
+++ b/boersencockpit/src/environments/environment.production.ts
@@ -1,12 +1,14 @@
-export const environment = {
+import { Environment } from './environment.model';
+
+export const environment: Environment = {
   production: true,
-  dataSource: 'alpha' as const,
+  dataSource: 'alpha',
   alphaVantage: {
     apiKey: '',
     baseUrl: 'https://www.alphavantage.co/query',
     maxRequestsPerMinute: 5,
     minRequestSpacingMs: 15000,
     cacheTtlMs: 5 * 60 * 1000,
-    enablePersistentCache: true
-  }
-} as const;
+    enablePersistentCache: true,
+  },
+};

--- a/boersencockpit/src/environments/environment.ts
+++ b/boersencockpit/src/environments/environment.ts
@@ -1,12 +1,14 @@
-export const environment = {
+import { Environment } from './environment.model';
+
+export const environment: Environment = {
   production: false,
-  dataSource: 'mock' as const,
+  dataSource: 'mock',
   alphaVantage: {
     apiKey: '',
     baseUrl: 'https://www.alphavantage.co/query',
     maxRequestsPerMinute: 5,
     minRequestSpacingMs: 15000,
     cacheTtlMs: 5 * 60 * 1000,
-    enablePersistentCache: false
-  }
-} as const;
+    enablePersistentCache: false,
+  },
+};


### PR DESCRIPTION
## Summary
- add shared environment typing to allow selecting Alpha Vantage at runtime
- ensure environment files use the shared typing and clean object literals
- add a GitHub Actions workflow that builds the Angular app on pushes and pull requests to main

## Testing
- npm start
- npm run build -- --configuration=production

------
https://chatgpt.com/codex/tasks/task_e_68d6c877529c8321ab189af3f5921bf5